### PR TITLE
For now, use a git dependency on cassandra-sys-rs.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ clippy = {version = "0.0", optional = true}
 libc = "0.2"
 num = "0.1"
 log = "0.3"
-cassandra-sys = "0.8"
+# TODO change to depend on v0.8.x once cassandra-sys moves into crates.io.
+cassandra-sys = { git = "https://github.com/Metaswitch/cassandra-sys-rs.git", branch = "master" }
 decimal = "0.2"
 chrono = "0.2"
 ip = "1.0"

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -31,7 +31,6 @@ use cassandra_sys::cass_cluster_set_port;
 use cassandra_sys::cass_cluster_set_protocol_version;
 use cassandra_sys::cass_cluster_set_queue_size_event;
 use cassandra_sys::cass_cluster_set_queue_size_io;
-use cassandra_sys::cass_cluster_set_queue_size_log;
 use cassandra_sys::cass_cluster_set_reconnect_wait_time;
 use cassandra_sys::cass_cluster_set_request_timeout;
 use cassandra_sys::cass_cluster_set_retry_policy;
@@ -222,19 +221,6 @@ impl Cluster {
             cass_cluster_set_queue_size_event(self.0, queue_size)
                 .to_result(self)
                 .chain_err(|| "couldn't set event queue size")
-        }
-    }
-
-    /// Sets the size of the fixed size queue that stores log messages.
-    ///
-    ///
-    /// Default: 8192
-    ///
-    pub fn set_queue_size_log(&mut self, queue_size: u32) -> Result<&mut Self> {
-        unsafe {
-            cass_cluster_set_queue_size_log(self.0, queue_size)
-                .to_result(self)
-                .chain_err(|| "couldn't set log queue size")
         }
     }
 


### PR DESCRIPTION
Required so we can depend on our own forked version of the
low-level binding.

Will be restored to a versioned dependency once our
cassandra-sys-rs is on crates.io.

Because cassandra-sys-rs no longer exports a symbol (which we do not
in fact use), we should no longer export it either.
See https://github.com/Metaswitch/cassandra-sys-rs/pull/2 and
https://datastax-oss.atlassian.net/browse/CPP-473 for details.