### PR TITLE
Fix the crate name in the `extern`/`use` lines of the readme example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,8 @@ Here's a straightforward example found in simple.rs:
 
 ```rust
     #[macro_use(stmt)]
-    extern crate cassandra;
-    use cassandra::*;
+    extern crate cassandra_cpp;
+    use cassandra_cpp::*;
     use std::str::FromStr;
 
 


### PR DESCRIPTION
When we published this crate to crates.io, we changed its name. We missed the references in the example (simple.rs) in the README, so it fails to compile.

This pull request fixes the readme to use the new crate name (and so fixes #12).

Signed-off-by: Angus Ireland <Angus.Ireland@metaswitch.com>