### PR TITLE
Expose more enums

### DIFF
--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -59,17 +59,12 @@ use std::net::AddrParseError;
 use std::net::Ipv4Addr;
 
 use std::result;
+use std::fmt::Display;
 use std::str::FromStr;
 use time::Duration;
 
-/// Possible Cql Protocol versions
-#[allow(missing_docs)]
-pub enum CqlProtocol {
-    ONE = 1,
-    TWO = 2,
-    THREE = 3,
-    FOUR = 4,
-}
+/// A CQL protocol version is just an integer.
+pub type CqlProtocol = i32;
 
 /// A set of cassandra contact points
 #[derive(Debug)]

--- a/src/cassandra/log.rs
+++ b/src/cassandra/log.rs
@@ -1,28 +1,42 @@
-use cassandra_sys::CassLogLevel;
+use cassandra_sys::CassLogLevel_;
 
 use cassandra_sys::CassLogMessage;
 
 // use cassandra_sys::cass_log_cleanup; @deprecated
-use cassandra_sys::cass_log_level_string;
 use cassandra_sys::cass_log_set_callback;
 use cassandra_sys::cass_log_set_level;
+use cassandra::util::Protected;
+
 use std::ffi::CStr;
 use std::os::raw;
 // use cassandra_sys::cass_log_set_queue_size; @deprecated
 
 
-#[repr(C)]
-/// The possible logging levels that can be set
-#[derive(Debug)]
-pub struct LogLevel(CassLogLevel);
-
-
-impl LogLevel {
-    /// Gets the string for a log level.
-    pub fn as_string(&self) -> String {
-        unsafe { CStr::from_ptr(cass_log_level_string(self.0)).to_str().expect("must be utf8").to_owned() }
-    }
+/// The possible logging levels that can be set.
+#[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
+#[allow(missing_docs)] // Meanings are defined in CQL documentation.
+#[allow(non_camel_case_types)] // Names are traditional.
+pub enum LogLevel {
+    DISABLED,
+    CRITICAL,
+    ERROR,
+    WARN,
+    INFO,
+    DEBUG,
+    TRACE,
+    LAST_ENTRY,
 }
+
+enhance_nullary_enum!(LogLevel, CassLogLevel_, {
+    (DISABLED, CASS_LOG_DISABLED, "DISABLED"),
+    (CRITICAL, CASS_LOG_CRITICAL, "CRITICAL"),
+    (ERROR, CASS_LOG_ERROR, "ERROR"),
+    (WARN, CASS_LOG_WARN, "WARN"),
+    (INFO, CASS_LOG_INFO, "INFO"),
+    (DEBUG, CASS_LOG_DEBUG, "DEBUG"),
+    (TRACE, CASS_LOG_TRACE, "TRACE"),
+    (LAST_ENTRY, CASS_LOG_LAST_ENTRY, "LAST_ENTRY"),
+});
 
 /// A callback that's used to handle logging.
 pub type CassLogCallback = Option<unsafe extern "C" fn(message: *const CassLogMessage, data: *mut raw::c_void)>;
@@ -31,8 +45,8 @@ pub type CassLogCallback = Option<unsafe extern "C" fn(message: *const CassLogMe
 ///
 /// <b>Note:</b> This needs to be done before any call that might log, such as
 /// any of the cass_cluster_*() or cass_ssl_*() functions.
-/// <b>Default:</b> CASS_LOG_WARN
-pub fn set_level(level: LogLevel) { unsafe { cass_log_set_level(level.0) } }
+/// <b>Default:</b> WARN
+pub fn set_level(level: LogLevel) { unsafe { cass_log_set_level(level.inner()) } }
 
 /// Sets a callback for handling logging events.
 pub fn set_callback(callback: CassLogCallback, mut data: Vec<u8>) {

--- a/src/cassandra/util.rs
+++ b/src/cassandra/util.rs
@@ -47,7 +47,7 @@ pub(crate) trait Protected<T> {
 macro_rules! enhance_nullary_enum {
     ( $this_name:ident, $that_name: ident, { $( ($this:ident, $that:ident, $name:expr), )* } ) => {
         impl ::std::fmt::Display for $this_name {
-            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> Result<(), ::std::fmt::Error> {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter) -> ::std::result::Result<(), ::std::fmt::Error> {
                 write!(f, "{}", match *self {
                     $( $this_name::$this => $name, )*
                 })
@@ -57,7 +57,7 @@ macro_rules! enhance_nullary_enum {
         impl ::std::str::FromStr for $this_name {
             type Err = String;
 
-            fn from_str(s: &str) -> Result<Self, Self::Err> {
+            fn from_str(s: &str) -> ::std::result::Result<Self, Self::Err> {
                 match s {
                     $( $name => Ok($this_name::$this), )*
                     _ => Err(format!("Unrecognized {}: {}", stringify!($this_name), s)),

--- a/src/cassandra/util.rs
+++ b/src/cassandra/util.rs
@@ -65,7 +65,7 @@ macro_rules! enhance_nullary_enum {
             }
         }
 
-        impl Protected<$that_name> for $this_name {
+        impl $crate::cassandra::util::Protected<$that_name> for $this_name {
             fn build(inner: $that_name) -> Self {
                 match inner {
                     $( $that_name::$that=> $this_name::$this ),*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,7 +44,7 @@ pub use cassandra::schema::keyspace_meta::KeyspaceMeta;
 pub use cassandra::schema::schema_meta::SchemaMeta;
 pub use cassandra::schema::table_meta::TableMeta;
 pub use cassandra::session::Session;
-pub use cassandra::ssl::Ssl;
+pub use cassandra::ssl::{Ssl, SslVerifyFlag};
 pub use cassandra::statement::BindRustType;
 pub use cassandra::statement::Statement;
 // pub use cassandra::custom_payload::CustomPayload;

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -84,3 +84,10 @@ fn test_parsing_printing_ssl_verify_flags() {
     assert_eq!("NONE".parse::<SslVerifyFlag>().unwrap(), SslVerifyFlag::NONE);
     let _ = "INVALID".parse::<SslVerifyFlag>().expect_err("Should have failed to parse");
 }
+
+#[test]
+fn test_using_cql_protocol_version() {
+    let mut cluster = Cluster::default();
+    cluster.set_protocol_version(4);
+    cluster.set_protocol_version(2);
+}

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -59,3 +59,28 @@ fn test_parsing_printing_loglevel() {
     assert_eq!("ERROR".parse::<LogLevel>().unwrap(), LogLevel::ERROR);
     let _ = "INVALID".parse::<LogLevel>().expect_err("Should have failed to parse");
 }
+
+#[test]
+fn test_using_ssl_verify_flags() {
+    let mut ssl = Ssl::default();
+    ssl.set_verify_flags(&vec![]);
+    ssl.set_verify_flags(&vec![SslVerifyFlag::NONE]);
+    ssl.set_verify_flags(&vec![SslVerifyFlag::PEER_CERT]);
+    ssl.set_verify_flags(&vec![SslVerifyFlag::PEER_IDENTITY_DNS, SslVerifyFlag::PEER_CERT]);
+}
+
+#[test]
+fn test_parsing_printing_ssl_verify_flags() {
+    for v in SslVerifyFlag::variants() {
+        let s = v.to_string();
+        let v2: SslVerifyFlag = s.parse().expect(&format!("Failed on {:?} as {}", v, s));
+        assert_eq!(v2, *v, "with intermediate {}", s);
+    }
+
+    // Just a few spot checks to confirm the formatting hasn't regressed
+    // or changed unexpectedly.
+    assert_eq!(SslVerifyFlag::PEER_IDENTITY_DNS.to_string(), "PEER_IDENTITY_DNS");
+    assert_eq!(format!("{}", SslVerifyFlag::PEER_CERT), "PEER_CERT");
+    assert_eq!("NONE".parse::<SslVerifyFlag>().unwrap(), SslVerifyFlag::NONE);
+    let _ = "INVALID".parse::<SslVerifyFlag>().expect_err("Should have failed to parse");
+}

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -34,3 +34,28 @@ fn test_parsing_printing_consistency() {
     assert_eq!("THREE".parse::<Consistency>().unwrap(), Consistency::THREE);
     let _ = "INVALID".parse::<Consistency>().expect_err("Should have failed to parse");
 }
+
+#[test]
+fn test_using_loglevel() {
+    set_level(LogLevel::DISABLED);
+    set_level(LogLevel::DEBUG);
+
+    assert!(LogLevel::DEBUG > LogLevel::WARN);
+    assert!(LogLevel::WARN > LogLevel::CRITICAL);
+}
+
+#[test]
+fn test_parsing_printing_loglevel() {
+    for v in LogLevel::variants() {
+        let s = v.to_string();
+        let v2: LogLevel = s.parse().expect(&format!("Failed on {:?} as {}", v, s));
+        assert_eq!(v2, *v, "with intermediate {}", s);
+    }
+
+    // Just a few spot checks to confirm the formatting hasn't regressed
+    // or changed unexpectedly.
+    assert_eq!(LogLevel::INFO.to_string(), "INFO");
+    assert_eq!(format!("{}", LogLevel::WARN), "WARN");
+    assert_eq!("ERROR".parse::<LogLevel>().unwrap(), LogLevel::ERROR);
+    let _ = "INVALID".parse::<LogLevel>().expect_err("Should have failed to parse");
+}


### PR DESCRIPTION
Exposes LogLevel, SslVerifyFlag, and CqlProtocolVersion more sensibly.

Notice that the SslVerifyFlags value is a set, and CqlProtocolVersion might as well just be an integer.