### PR TITLE
Fix contact point handling and logging

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ travis-ci = { repository = "Metaswitch/cassandra-rs" }
 clippy = {version = "0.0", optional = true}
 libc = "0.2"
 num = "0.1"
+slog = "2"
 cassandra-cpp-sys = "0.8"
 decimal = "0.2"
 chrono = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ travis-ci = { repository = "Metaswitch/cassandra-rs" }
 clippy = {version = "0.0", optional = true}
 libc = "0.2"
 num = "0.1"
-log = "0.3"
 cassandra-cpp-sys = "0.8"
 decimal = "0.2"
 chrono = "0.2"

--- a/examples/disabled/logging.rs
+++ b/examples/disabled/logging.rs
@@ -12,7 +12,7 @@ fn print_error(future: &mut Future) {
 
 unsafe fn create_cluster() -> Result<CassError,Cluster> {
     let cluster = Cluster::default();
-    cluster.set_contact_points(ContactPoints::from_str("127.0.0.1,127.0.0.2,127.0.0.3")?);
+    cluster.set_contact_points("127.0.0.1,127.0.0.2,127.0.0.3")?;
     cluster
 }
 

--- a/examples/schema_meta.rs
+++ b/examples/schema_meta.rs
@@ -4,7 +4,6 @@ extern crate cassandra_cpp;
 
 use cassandra_cpp::*;
 use errors::*;
-use std::str::FromStr;
 
 
 fn print_function(session: &Session, keyspace: &str, function: &str, arguments: Vec<&str>) -> Result<()> {
@@ -113,7 +112,7 @@ fn main() {
 
 fn cass() -> Result<()> {
     let mut cluster = Cluster::default();
-    cluster.set_contact_points(ContactPoints::from_str("127.0.0.1").unwrap()).unwrap();
+    cluster.set_contact_points("127.0.0.1").unwrap();
     cluster.set_load_balance_round_robin();
 
     let create_ks = stmt!("CREATE KEYSPACE IF NOT EXISTS examples WITH replication = { \'class\': \

--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,13 +1,12 @@
 #[macro_use(stmt)]
 extern crate cassandra_cpp;
 use cassandra_cpp::*;
-use std::str::FromStr;
 
 fn main() {
     let query = stmt!("SELECT keyspace_name FROM system_schema.keyspaces;");
     let col_name = "keyspace_name";
 
-    let contact_points = ContactPoints::from_str("127.0.0.1").unwrap();
+    let contact_points = "127.0.0.1";
 
     let mut cluster = Cluster::default();
     cluster.set_contact_points(contact_points).unwrap();

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -73,11 +73,10 @@ pub type CqlProtocol = i32;
 ///
 /// # Examples
 /// ```
-/// use std::str::FromStr;
 /// use cassandra_cpp::Cluster;
 /// let mut cluster = Cluster::default();
 /// cluster.set_contact_points("127.0.0.1").unwrap();
-/// let mut session = cluster.connect().unwrap();
+/// let _session = cluster.connect().unwrap();
 /// ```
 #[derive(Debug)]
 pub struct Cluster(pub *mut _Cluster);

--- a/src/cassandra/column.rs
+++ b/src/cassandra/column.rs
@@ -278,7 +278,7 @@ impl Column {
         }
     }
 
-    /// Gets the blog from this column or errors if type if wrong
+    /// Gets the blob from this column or errors if type if wrong
     pub fn get_blob(&self) -> Result<Vec<u8>> {
         unsafe {
             match cass_value_type(self.0) {

--- a/src/cassandra/future.rs
+++ b/src/cassandra/future.rs
@@ -261,7 +261,6 @@ impl SessionFuture {
     pub fn get(&self) -> Option<CassResult> {
         unsafe {
             let result = cass_future_get_result(self.0);
-            debug!("result is null: {}", result.is_null());
             if result.is_null() {
                 None
             } else {

--- a/src/cassandra/log.rs
+++ b/src/cassandra/log.rs
@@ -1,16 +1,14 @@
 use cassandra_sys::CassLogLevel_;
-
 use cassandra_sys::CassLogMessage;
-
 // use cassandra_sys::cass_log_cleanup; @deprecated
 use cassandra_sys::cass_log_set_callback;
 use cassandra_sys::cass_log_set_level;
 use cassandra::util::Protected;
+// use cassandra_sys::cass_log_set_queue_size; @deprecated
 
 use std::ffi::CStr;
 use std::os::raw;
-// use cassandra_sys::cass_log_set_queue_size; @deprecated
-
+use slog;
 
 /// The possible logging levels that can be set.
 #[derive(Debug, Eq, PartialEq, PartialOrd, Ord)]
@@ -48,7 +46,9 @@ pub type CassLogCallback = Option<unsafe extern "C" fn(message: *const CassLogMe
 /// <b>Default:</b> WARN
 pub fn set_level(level: LogLevel) { unsafe { cass_log_set_level(level.inner()) } }
 
-/// Sets a callback for handling logging events.
-pub fn set_callback(callback: CassLogCallback, mut data: Vec<u8>) {
-    unsafe { cass_log_set_callback(callback, &mut data as *mut _ as *mut raw::c_void) }
+/// Sets a logger to receive all Cassandra driver logs.
+pub fn set_logger(logger: slog::Logger) {
+    unsafe {
+        // TODO cass_log_set_callback(callback, &mut data as *mut _ as *mut raw::c_void)
+    }
 }

--- a/src/cassandra/log.rs
+++ b/src/cassandra/log.rs
@@ -1,6 +1,7 @@
 use cassandra_sys::CassLogLevel_;
 use cassandra_sys::CassLogMessage;
 // use cassandra_sys::cass_log_cleanup; @deprecated
+use cassandra_sys::CassLogCallback;
 use cassandra_sys::cass_log_set_callback;
 use cassandra_sys::cass_log_set_level;
 use cassandra::util::Protected;
@@ -8,6 +9,9 @@ use cassandra::util::Protected;
 
 use std::ffi::CStr;
 use std::os::raw;
+use std::ptr;
+use std::boxed::Box;
+use std::borrow::Borrow;
 use slog;
 
 /// The possible logging levels that can be set.
@@ -36,9 +40,6 @@ enhance_nullary_enum!(LogLevel, CassLogLevel_, {
     (LAST_ENTRY, CASS_LOG_LAST_ENTRY, "LAST_ENTRY"),
 });
 
-/// A callback that's used to handle logging.
-pub type CassLogCallback = Option<unsafe extern "C" fn(message: *const CassLogMessage, data: *mut raw::c_void)>;
-
 /// Sets the log level.
 ///
 /// <b>Note:</b> This needs to be done before any call that might log, such as
@@ -46,9 +47,52 @@ pub type CassLogCallback = Option<unsafe extern "C" fn(message: *const CassLogMe
 /// <b>Default:</b> WARN
 pub fn set_level(level: LogLevel) { unsafe { cass_log_set_level(level.inner()) } }
 
-/// Sets a logger to receive all Cassandra driver logs.
-pub fn set_logger(logger: slog::Logger) {
+/// Called by Cassandra for every log if logging is enabled. Passes the log to the configured
+/// slog logger.
+unsafe extern "C" fn logger_callback(log: *const CassLogMessage, data: *mut raw::c_void) {
+    let log = &*log;
+    let logger: &slog::Logger = &*(data as *const _);
+
+    let message: &str = &CStr::from_ptr(log.message.as_ptr()).to_string_lossy();
+    let time_ms: u64 = log.time_ms;
+    let file: &str = &CStr::from_ptr(log.file).to_string_lossy();
+    let line: i32 = log.line;
+    let function: &str = &CStr::from_ptr(log.file).to_string_lossy();
+    let kv = o!(
+        "time_ms" => time_ms,
+        "file" => file,
+        "line" => line,
+        "function" => function
+    );
+
+    // Issue the correct level of log call. Sadly even though the `log!` macro exists,
+    // it's fundamental to slog that the log level is statically known for a given invocation.
+    // We can't do that in this case, so we have to use this tedious workaround.
+    match log.severity {
+        CassLogLevel_::CASS_LOG_DISABLED |
+        CassLogLevel_::CASS_LOG_CRITICAL => crit!(logger, "{}", message; kv),
+        CassLogLevel_::CASS_LOG_ERROR => error!(logger, "{}", message; kv),
+        CassLogLevel_::CASS_LOG_WARN => warn!(logger, "{}", message; kv),
+        CassLogLevel_::CASS_LOG_INFO => info!(logger, "{}", message; kv),
+        CassLogLevel_::CASS_LOG_DEBUG => debug!(logger, "{}", message; kv),
+        CassLogLevel_::CASS_LOG_TRACE |
+        CassLogLevel_::CASS_LOG_LAST_ENTRY => trace!(logger, "{}", message; kv),
+    };
+}
+
+/// Set or unset a logger to receive all Cassandra driver logs.
+pub fn set_logger(logger: Option<slog::Logger>) {
     unsafe {
-        // TODO cass_log_set_callback(callback, &mut data as *mut _ as *mut raw::c_void)
+        match logger {
+            Some(logger) => {
+                // Pass ownership to C. In fact we leak the logger; it never gets freed.
+                // We don't expect this to be called many times, so we're not worried.
+                let data = Box::new(logger);
+                cass_log_set_callback(Some(logger_callback), Box::into_raw(data) as _)
+            },
+            None => {
+                cass_log_set_callback(None, ptr::null_mut())
+            },
+        }
     }
 }

--- a/src/cassandra/metrics.rs
+++ b/src/cassandra/metrics.rs
@@ -1,12 +1,62 @@
 use cassandra::util::Protected;
 use cassandra_sys::CassMetrics as _CassMetrics;
 
-/// A view into server metrics FIXME not meaingfully implemented
+/// Metrics about the current session.
+#[allow(missing_docs)] // See DataStax docs
 #[derive(Debug)]
-pub struct SessionMetrics(*const _CassMetrics);
+pub struct SessionMetrics {
+    pub min_us: u64,
+    pub max_us: u64,
+    pub mean_us: u64,
+    pub stddev_us: u64,
+    pub median_us: u64,
+    pub percentile_75th_us: u64,
+    pub percentile_95th_us: u64,
+    pub percentile_98th_us: u64,
+    pub percentile_99th_us: u64,
+    pub percentile_999th_us: u64,
 
+    pub mean_rate_per_sec: f64,
+    pub one_minute_rate_per_seq: f64,
+    pub five_minute_rate_per_sec: f64,
+    pub fifteen_minute_rate_per_sec: f64,
 
-impl Protected<*const _CassMetrics> for SessionMetrics {
-    fn inner(&self) -> *const _CassMetrics { self.0 }
-    fn build(inner: *const _CassMetrics) -> Self { SessionMetrics(inner) }
+    pub total_connections: u64,
+    pub available_connections: u64,
+    pub exceeded_pending_requests_water_mark: u64,
+    pub exceeded_write_bytes_water_mark: u64,
+
+    pub connection_timeouts: u64,
+    pub pending_request_timeouts: u64,
+    pub request_timeouts: u64,
+}
+
+impl SessionMetrics {
+    /// Build session metrics from underlying type.
+    pub(crate) fn build(inner: *const _CassMetrics) -> Self {
+        let inner = unsafe { &*inner };
+        SessionMetrics {
+            min_us: inner.requests.min,
+            max_us: inner.requests.max,
+            mean_us: inner.requests.mean,
+            stddev_us: inner.requests.stddev,
+            median_us: inner.requests.median,
+            percentile_75th_us: inner.requests.percentile_75th,
+            percentile_95th_us: inner.requests.percentile_95th,
+            percentile_98th_us: inner.requests.percentile_98th,
+            percentile_99th_us: inner.requests.percentile_99th,
+            percentile_999th_us: inner.requests.percentile_999th,
+            mean_rate_per_sec: inner.requests.mean_rate,
+            one_minute_rate_per_seq: inner.requests.one_minute_rate,
+            five_minute_rate_per_sec: inner.requests.five_minute_rate,
+            fifteen_minute_rate_per_sec: inner.requests.fifteen_minute_rate,
+            total_connections: inner.stats.total_connections,
+            available_connections: inner.stats.available_connections,
+            exceeded_pending_requests_water_mark: inner.stats.exceeded_pending_requests_water_mark,
+            exceeded_write_bytes_water_mark: inner.stats.exceeded_write_bytes_water_mark,
+            connection_timeouts: inner.errors.connection_timeouts,
+            pending_request_timeouts: inner.errors.pending_request_timeouts,
+            request_timeouts: inner.errors.request_timeouts,
+        }
+    }
 }

--- a/src/cassandra/session.rs
+++ b/src/cassandra/session.rs
@@ -47,7 +47,6 @@ impl Drop for Session {
     /// Frees a session instance. If the session is still connected it will be synchronously
     /// closed before being deallocated.
     fn drop(&mut self) {
-        debug!("dropping session");
         unsafe { cass_session_free(self.0) }
     }
 }

--- a/src/cassandra/value.rs
+++ b/src/cassandra/value.rs
@@ -144,14 +144,12 @@ impl Debug for Value {
                     Ok(())
                 }
                 CASS_VALUE_TYPE_UDT => {
-                    debug!("unimplemented for udt!");
                     //                    for item in self.as_map_iterator().unwrap() {
                     //                        try!(write!(f, "MAP {:?}:{:?}", item.0,item.1))
                     //                    }
                     Ok(())
                 }
                 CASS_VALUE_TYPE_TUPLE => {
-                    debug!("unimplemented for tuple!");
                     //                    for item in self.as_map_iterator().unwrap() {
                     //                        try!(write!(f, "MAP {:?}:{:?}", item.0,item.1))
                     //                    }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,8 +8,6 @@
 #![recursion_limit = "1024"]
 
 extern crate libc;
-#[macro_use]
-extern crate log;
 extern crate decimal;
 extern crate chrono;
 extern crate time;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,8 @@
 #![recursion_limit = "1024"]
 
 extern crate libc;
+#[macro_use]
+extern crate slog;
 extern crate decimal;
 extern crate chrono;
 extern crate time;
@@ -29,7 +31,7 @@ pub use cassandra::inet::Inet;
 // pub use cassandra::metrics::*;
 pub use cassandra::iterator::{AggregateIterator, ColumnIterator, FieldIterator, FunctionIterator, KeyspaceIterator,
                               MapIterator, SetIterator, TableIterator, UserTypeIterator};
-pub use cassandra::log::{LogLevel, set_callback, set_level};
+pub use cassandra::log::{LogLevel, set_logger, set_level};
 pub use cassandra::policy::retry::RetryPolicy;
 pub use cassandra::prepared::PreparedStatement;
 pub use cassandra::result::CassResult;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,7 +18,7 @@ extern crate uuid;
 
 
 pub use cassandra::batch::{Batch, BatchType, CustomPayload};
-pub use cassandra::cluster::{Cluster, ContactPoints, CqlProtocol}; //FIXME this should not be exported
+pub use cassandra::cluster::{Cluster, CqlProtocol}; //FIXME this should not be exported
 pub use cassandra::collection::{CassCollection, List, Map, Set};
 pub use cassandra::column::Column;
 pub use cassandra::consistency::Consistency;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -209,7 +209,7 @@ fn test_null_insertion() {
     s.bind(3, 2.72f64).unwrap();
     // deliberately omit 4 - this should be equivalent to binding null
     s.bind_null(5).unwrap();
-    session.execute(&s).wait();
+    session.execute(&s).wait().unwrap();
 
     // Read them back.
     let s = stmt!("SELECT key, bln, flt, dbl, i32, i64 FROM examples.basic WHERE key = 'shrdlu';");

--- a/tests/help/mod.rs
+++ b/tests/help/mod.rs
@@ -1,10 +1,9 @@
 use cassandra_cpp::*;
-use std::str::FromStr;
 
 
 /// Get a new session to the test Cassandra instance.
 pub fn create_test_session() -> Session {
-    let contact_points = ContactPoints::from_str("127.0.0.1").unwrap();
+    let contact_points = "127.0.0.1";
 
     let mut cluster = Cluster::default();
     cluster.set_contact_points(contact_points).unwrap();

--- a/tests/help/mod.rs
+++ b/tests/help/mod.rs
@@ -1,3 +1,7 @@
+//! Helper methods for test code.
+//!
+#![allow(dead_code)] // Some functions are only used in some tests.
+
 use cassandra_cpp::*;
 
 

--- a/tests/logging.rs
+++ b/tests/logging.rs
@@ -45,3 +45,13 @@ fn test_logging() {
     let log_output: String = drain.0.lock().unwrap().clone();
     assert!(log_output.contains("Unable to resolve address for absolute-gibberish.invalid"), log_output);
 }
+
+#[test]
+fn test_metrics() {
+    let query = stmt!("SELECT keyspace_name FROM system_schema.keyspaces;");
+    let session = help::create_test_session();
+    session.execute(&query).wait().unwrap();
+    let metrics = session.get_metrics();
+    assert_eq!(metrics.total_connections, 1);
+    assert(metrics.min_us > 0);
+}

--- a/tests/logging.rs
+++ b/tests/logging.rs
@@ -1,0 +1,45 @@
+#[macro_use(stmt)]
+extern crate cassandra_cpp;
+extern crate slog;
+
+mod help;
+
+use cassandra_cpp::*;
+
+use std::sync::Arc;
+use std::sync::Mutex;
+use slog::*;
+
+#[derive(Clone)]
+struct MyDrain(Arc<Mutex<String>>);
+
+impl Default for MyDrain {
+    fn default() -> Self {
+        MyDrain(Arc::new(Mutex::new("".to_string())))
+    }
+}
+
+impl Drain for MyDrain {
+    type Ok = ();
+    type Err = ();
+
+    fn log(&self, record: &Record, values: &OwnedKVList) -> ::std::result::Result<Self::Ok, Self::Err> {
+        self.0.lock().unwrap().push_str(&format!("{}", record.msg()));
+        Ok(())
+    }
+}
+
+#[test]
+fn test_logging() {
+    let drain = MyDrain::default();
+    let logger = Logger::root(drain.clone().fuse(), o!());
+
+    set_level(LogLevel::WARN);
+    set_logger(logger);
+
+    let mut cluster = Cluster::default();
+    cluster.set_contact_points("absolute-gibberish.invalid").unwrap();
+    cluster.connect().expect_err("Should fail to connect");
+
+    assert!(drain.0.lock().unwrap().contains("cannot for hte life of me"), drain.0);
+}

--- a/tests/logging.rs
+++ b/tests/logging.rs
@@ -53,5 +53,5 @@ fn test_metrics() {
     session.execute(&query).wait().unwrap();
     let metrics = session.get_metrics();
     assert_eq!(metrics.total_connections, 1);
-    assert(metrics.min_us > 0);
+    assert!(metrics.min_us > 0);
 }

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -88,6 +88,6 @@ fn test_parsing_printing_ssl_verify_flags() {
 #[test]
 fn test_using_cql_protocol_version() {
     let mut cluster = Cluster::default();
-    cluster.set_protocol_version(4);
-    cluster.set_protocol_version(2);
+    cluster.set_protocol_version(4).unwrap();
+    cluster.set_protocol_version(2).unwrap();
 }


### PR DESCRIPTION
As it says. Contact points should just be a string: no sense in converting to a Rust type and then back to a string again; we want the DNS and IPv6 behaviour of the underlying C++ library. There were some vestiges of old logging which are removed; this now adds proper structured logging using slog.

Also fixes or silences some warnings.