### PR TITLE
Fix Cassandra BatchType

### DIFF
--- a/src/cassandra/batch.rs
+++ b/src/cassandra/batch.rs
@@ -4,8 +4,8 @@ use cassandra::statement::Statement;
 use cassandra::util::Protected;
 
 use cassandra_sys::CASS_OK;
-pub use cassandra_sys::CassBatch as _Batch;
-pub use cassandra_sys::CassBatchType as BatchType;
+use cassandra_sys::CassBatch as _Batch;
+use cassandra_sys::CassBatchType_;
 use cassandra_sys::CassConsistency;
 use cassandra_sys::CassCustomPayload as _CassCustomPayload;
 use cassandra_sys::CassError;
@@ -81,7 +81,7 @@ impl Drop for Batch {
 
 impl Batch {
     /// Creates a new batch statement with batch type.
-    pub fn new(batch_type: BatchType) -> Batch { unsafe { Batch(cass_batch_new(batch_type)) } }
+    pub fn new(batch_type: BatchType) -> Batch { unsafe { Batch(cass_batch_new(batch_type.inner())) } }
 
     /// Sets the batch's consistency level
     pub fn set_consistency(&mut self, consistency: Consistency) -> Result<&Self, CassError> {
@@ -145,3 +145,19 @@ impl Batch {
         }
     }
 }
+
+/// A type of batch.
+#[derive(Debug, Eq, PartialEq)]
+#[allow(missing_docs)] // Meanings are defined in CQL documentation.
+#[allow(non_camel_case_types)] // Names are traditional.
+pub enum BatchType {
+    LOGGED,
+    UNLOGGED,
+    COUNTER,
+}
+
+enhance_nullary_enum!(BatchType, CassBatchType_, {
+    (LOGGED, CASS_BATCH_TYPE_LOGGED, "LOGGED"),
+    (UNLOGGED, CASS_BATCH_TYPE_UNLOGGED, "UNLOGGED"),
+    (COUNTER, CASS_BATCH_TYPE_COUNTER, "COUNTER"),
+});

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -53,9 +53,6 @@ pub use cassandra::tuple::Tuple;
 pub use cassandra::user_type::UserType;
 pub use cassandra::uuid::{Uuid, UuidGen};
 pub use cassandra::value::{Value, ValueType};
-// pub use cassandra::inet::{Inet};
-pub use cassandra_sys::CASS_BATCH_TYPE_LOGGED;
-pub use cassandra_sys::CassBatchType;
 
 extern crate cassandra_cpp_sys;
 use cassandra_cpp_sys as cassandra_sys;

--- a/tests/batch.rs
+++ b/tests/batch.rs
@@ -16,7 +16,7 @@ struct Pair {
 fn insert_into_batch_with_prepared(session: &Session, pairs: &Vec<Pair>) -> Result<PreparedStatement> {
     let insert_query = "INSERT INTO examples.pairs (key, value) VALUES (?, ?)";
     let prepared = session.prepare(insert_query).unwrap().wait().unwrap();
-    let mut batch = Batch::new(CASS_BATCH_TYPE_LOGGED);
+    let mut batch = Batch::new(BatchType::LOGGED);
     for pair in pairs {
         let mut statement = prepared.bind();
         statement.bind(0, pair.key.as_ref())?;

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -11,7 +11,7 @@ fn test_using_consistency() {
     s.set_consistency(Consistency::LOCAL_ONE).unwrap();
     s.set_serial_consistency(Consistency::SERIAL).unwrap();
 
-    let mut batch = Batch::new(CASS_BATCH_TYPE_LOGGED);
+    let mut batch = Batch::new(BatchType::LOGGED);
     batch.add_statement(&s).unwrap();
     batch.set_consistency(Consistency::TWO).unwrap();
     batch.set_serial_consistency(Consistency::LOCAL_SERIAL).unwrap();
@@ -90,4 +90,20 @@ fn test_using_cql_protocol_version() {
     let mut cluster = Cluster::default();
     cluster.set_protocol_version(4).unwrap();
     cluster.set_protocol_version(2).unwrap();
+}
+
+#[test]
+fn test_parsing_printing_batch_type() {
+    for v in BatchType::variants() {
+        let s = v.to_string();
+        let v2: BatchType = s.parse().expect(&format!("Failed on {:?} as {}", v, s));
+        assert_eq!(v2, *v, "with intermediate {}", s);
+    }
+
+    // Just a few spot checks to confirm the formatting hasn't regressed
+    // or changed unexpectedly.
+    assert_eq!(BatchType::LOGGED.to_string(), "LOGGED");
+    assert_eq!(format!("{}", BatchType::UNLOGGED), "UNLOGGED");
+    assert_eq!("COUNTER".parse::<BatchType>().unwrap(), BatchType::COUNTER);
+    let _ = "INVALID".parse::<BatchType>().expect_err("Should have failed to parse");
 }


### PR DESCRIPTION
Expose BatchType as a properly-wrapped type owned by cassandra-cpp, rather than directly as the underlying cassandra-cpp-sys type.

Exactly the same as, e.g., `Consistency`.