### PR TITLE
Add statement request timeout wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Fixed buggy IPv6 conversions.
 * `Inet::cass_inet_init_v4` and `Inet::cass_inet_init_v6` no longer consume their arguments.
 * `Tuple::set_inet()` now takes an `IpAddr` rather than a `SocketAddr`.
+* Added wrapper for `cass_statement_set_request_timeout`.
 
 ## 0.10.2 (2017-09-11)
 

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -61,9 +61,11 @@ use cassandra_sys::cass_statement_set_paging_state_token;
 use cassandra_sys::cass_statement_set_retry_policy;
 use cassandra_sys::cass_statement_set_serial_consistency;
 use cassandra_sys::cass_statement_set_timestamp;
+use cassandra_sys::cass_statement_set_request_timeout;
 use cassandra_sys::cass_true;
 
 use std::ffi::CString;
+use time::Duration;
 /// A statement object is an executable query. It represents either a regular
 /// (adhoc) statement or a prepared statement. It maintains the queries' parameter
 /// values along with query options (consistency level, paging state, etc.)
@@ -279,6 +281,14 @@ impl Statement {
     pub fn set_timestamp(&mut self, timestamp: i64) -> Result<&mut Self> {
         unsafe {
             cass_statement_set_timestamp(self.0, timestamp)
+                .to_result(self)
+        }
+    }
+
+    /// Sets the statement's timeout for waiting for a response from a node.
+    pub fn set_statement_request_timeout(&mut self, timeout: Duration) -> Result<&mut Self> {
+        unsafe {
+            cass_statement_set_request_timeout(self.0, timeout.num_milliseconds() as u64)
                 .to_result(self)
         }
     }

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -286,11 +286,11 @@ impl Statement {
     }
 
     /// Sets the statement's timeout for waiting for a response from a node.
-    pub fn set_statement_request_timeout(&mut self, timeout: Duration) -> Result<&mut Self> {
+    pub fn set_statement_request_timeout(&mut self, timeout: Duration) -> &Self {
         unsafe {
-            cass_statement_set_request_timeout(self.0, timeout.num_milliseconds() as u64)
-                .to_result(self)
+            cass_statement_set_request_timeout(self.0, timeout.num_milliseconds() as u64);
         }
+        self
     }
 
     /// Sets the statement's retry policy.

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -12,7 +12,6 @@ use cassandra::user_type::UserType;
 use cassandra::util::Protected;
 use cassandra::uuid::Uuid;
 use cassandra::error::*;
-use cassandra_sys::CASS_UINT64_MAX;
 
 use cassandra_sys::CassStatement as _Statement;
 use cassandra_sys::cass_false;
@@ -64,6 +63,7 @@ use cassandra_sys::cass_statement_set_serial_consistency;
 use cassandra_sys::cass_statement_set_timestamp;
 use cassandra_sys::cass_statement_set_request_timeout;
 use cassandra_sys::cass_true;
+use cassandra_sys::CASS_UINT64_MAX;
 
 use std::ffi::CString;
 use time::Duration;

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -12,6 +12,7 @@ use cassandra::user_type::UserType;
 use cassandra::util::Protected;
 use cassandra::uuid::Uuid;
 use cassandra::error::*;
+use cassandra_sys::CASS_UINT64_MAX;
 
 use cassandra_sys::CassStatement as _Statement;
 use cassandra_sys::cass_false;
@@ -286,9 +287,13 @@ impl Statement {
     }
 
     /// Sets the statement's timeout for waiting for a response from a node.
-    pub fn set_statement_request_timeout(&mut self, timeout: Duration) -> &Self {
+    pub fn set_statement_request_timeout(&mut self, timeout: Option<Duration>) -> &mut Self {
         unsafe {
-            cass_statement_set_request_timeout(self.0, timeout.num_milliseconds() as u64);
+            let timeout_millis = match timeout {
+                None => CASS_UINT64_MAX as u64,
+                Some(time) => time.num_milliseconds() as u64,
+            };
+            cass_statement_set_request_timeout(self.0, timeout_millis);
         }
         self
     }

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -287,6 +287,8 @@ impl Statement {
     }
 
     /// Sets the statement's timeout for waiting for a response from a node.
+    /// Some(Duration::milliseconds(0)) sets no timeout, and None disables it
+    /// (to use the cluster-level request timeout).
     pub fn set_statement_request_timeout(&mut self, timeout: Option<Duration>) -> &mut Self {
         unsafe {
             let timeout_millis = match timeout {

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,11 +1,13 @@
 #[macro_use(stmt)]
 extern crate cassandra_cpp;
 extern crate futures;
+extern crate time;
 
 mod help;
 
 use cassandra_cpp::*;
 use futures::Future;
+use time::Duration;
 
 
 #[derive(Debug,PartialEq,Clone,Copy)]
@@ -310,6 +312,19 @@ fn test_error_reporting() {
 #[test]
 fn test_result() {
     let query = stmt!("SELECT * FROM system_schema.tables;");
+    let session = help::create_test_session();
+    let result = session.execute(&query).wait().unwrap();
+
+    assert_eq!("keyspace_name", result.column_name(0).unwrap());
+    assert_eq!("table_name", result.column_name(1).unwrap());
+}
+
+#[test]
+fn test_statement_timeout() {
+    let mut query = stmt!("SELECT * FROM system_schema.tables;");
+    query.set_statement_request_timeout(Some(Duration::milliseconds(
+        30000 as i64,
+    )));
     let session = help::create_test_session();
     let result = session.execute(&query).wait().unwrap();
 


### PR DESCRIPTION
Add wrapper for cass_statement_set_request_timeout. Styled on the similar wrapper for cass_cluster_set_request_timeout.

I cannot find any tests for similar functions in the code base, so I haven't added one for this, please let me know if there should be.