### PR TITLE
Fix unsafe lifetimes

### DIFF
--- a/src/cassandra/batch.rs
+++ b/src/cassandra/batch.rs
@@ -54,8 +54,9 @@ impl CustomPayload {
     /// Sets an item to the custom payload.
     pub fn set(&self, name: String, value: &[u8]) -> Result<()> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             Ok(cass_custom_payload_set(self.0,
-                                       CString::new(name)?.as_ptr(),
+                                       name_cstr.as_ptr(),
                                        value.as_ptr(),
                                        value.len()))
         }

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -352,9 +352,11 @@ impl Cluster {
     /// Sets credentials for plain text authentication.
     pub fn set_credentials(&mut self, username: &str, password: &str) -> Result<&mut Self> {
         unsafe {
+            let username_cstr = CString::new(username)?;
+            let password_cstr = CString::new(password)?;
             cass_cluster_set_credentials(self.0,
-                                         CString::new(username)?.as_ptr(),
-                                         CString::new(password)?.as_ptr());
+                                         username_cstr.as_ptr(),
+                                         password_cstr.as_ptr());
         }
         Ok(self)
     }

--- a/src/cassandra/data_type.rs
+++ b/src/cassandra/data_type.rs
@@ -90,8 +90,9 @@ impl DataType {
     pub fn set_type_name<S>(data_type: DataType, type_name: S) -> Result<()>
         where S: Into<String> {
         unsafe {
+            let type_name_cstr = CString::new(type_name.into())?;
             cass_data_type_set_type_name(data_type.0,
-                                         CString::new(type_name.into())?.as_ptr())
+                                         type_name_cstr.as_ptr())
                 .to_result(())
         }
     }
@@ -117,8 +118,9 @@ impl DataType {
     pub fn set_keyspace<S>(data_type: DataType, keyspace: S) -> Result<()>
         where S: Into<String> {
         unsafe {
+            let keyspace_cstr = CString::new(keyspace.into())?;
             cass_data_type_set_keyspace(data_type.0,
-                                        CString::new(keyspace.into())?.as_ptr())
+                                        keyspace_cstr.as_ptr())
                 .to_result(())
 
         }
@@ -145,8 +147,9 @@ impl DataType {
     pub fn set_class_name<S>(&self, class_name: S) -> Result<()>
         where S: Into<String> {
         unsafe {
+            let class_name_cstr = CString::new(class_name.into())?;
             cass_data_type_set_class_name(self.0,
-                                          CString::new(class_name.into())?.as_ptr())
+                                          class_name_cstr.as_ptr())
                 .to_result(())
         }
     }
@@ -171,9 +174,9 @@ impl DataType {
     pub fn sub_data_type_by_name<S>(data_type: DataType, name: S) -> ConstDataType
         where S: Into<String> {
         unsafe {
+            let name_cstr = CString::new(name.into()).expect("must be utf8");
             ConstDataType(cass_data_type_sub_data_type_by_name(data_type.0,
-                                                               CString::new(name.into())
-                                                                   .expect("must be utf8")
+                                                               name_cstr
                                                                    .as_ptr()))
         }
     }
@@ -212,8 +215,9 @@ impl DataType {
     pub fn add_sub_type_by_name<S>(&mut self, name: S, sub_data_type: DataType) -> Result<()>
         where S: Into<String> {
         unsafe {
+            let sub_data_type_cstr = CString::new(name.into())?;
             cass_data_type_add_sub_type_by_name(self.0,
-                                                CString::new(name.into())?.as_ptr(),
+                                                sub_data_type_cstr.as_ptr(),
                                                 sub_data_type.0)
                 .to_result(())
 
@@ -238,8 +242,9 @@ impl DataType {
     pub fn add_sub_value_type_by_name<S>(&self, name: &str, typ: ValueType) -> Result<()>
         where S: Into<String> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_data_type_add_sub_value_type_by_name(self.0,
-                                                      CString::new(name)?.as_ptr(),
+                                                      name_cstr.as_ptr(),
                                                       typ.inner())
                 .to_result(())
         }

--- a/src/cassandra/prepared.rs
+++ b/src/cassandra/prepared.rs
@@ -68,10 +68,9 @@ impl PreparedStatement {
     /// this reference as it is bound to the lifetime of the prepared.
     pub fn parameter_data_type_by_name(&self, name: &str) -> ConstDataType {
         unsafe {
+            let name_cstr = CString::new(name).expect("must be utf8");
             ConstDataType(cass_prepared_parameter_data_type_by_name(self.0,
-                                                                    CString::new(name)
-                                                                        .expect("must be utf8")
-                                                                        .as_ptr()))
+                                                                    name_cstr.as_ptr()))
         }
     }
 }

--- a/src/cassandra/row.rs
+++ b/src/cassandra/row.rs
@@ -193,8 +193,9 @@ impl Row {
     pub fn get_column_by_name<S>(&self, name: S) -> Result<Value>
         where S: Into<String> {
         unsafe {
+            let name_cstr = CString::new(name.into())?;
             let col = cass_row_get_column_by_name(self.0,
-                                                  CString::new(name.into())?.as_ptr());
+                                                  name_cstr.as_ptr());
             if col.is_null() {
                 Err(CassErrorCode::LIB_INDEX_OUT_OF_BOUNDS.to_error())
             } else {

--- a/src/cassandra/schema/aggregate_meta.rs
+++ b/src/cassandra/schema/aggregate_meta.rs
@@ -85,7 +85,8 @@ impl AggregateMeta {
     /// access to the column data found in the underlying "aggregates" metadata table.
     pub fn field_by_name(&self, name: &str) -> Option<Value> {
         unsafe {
-            let agg = cass_aggregate_meta_field_by_name(self.0, CString::new(name).expect("must be utf8").as_ptr());
+            let name_cstr = CString::new(name).expect("must be utf8");
+            let agg = cass_aggregate_meta_field_by_name(self.0, name_cstr.as_ptr());
             if agg.is_null() {
                 None
             } else {

--- a/src/cassandra/schema/column_meta.rs
+++ b/src/cassandra/schema/column_meta.rs
@@ -54,7 +54,8 @@ impl ColumnMeta {
     /// access to the column data found in the underlying "columns" metadata table.
     pub fn field_by_name(&self, name: &str) -> Option<Value> {
         unsafe {
-            let field = cass_column_meta_field_by_name(self.0, CString::new(name).expect("must be utf8").as_ptr());
+            let name_cstr = CString::new(name).expect("must be utf8");
+            let field = cass_column_meta_field_by_name(self.0, name_cstr.as_ptr());
             if field.is_null() {
                 None
             } else {

--- a/src/cassandra/schema/function_meta.rs
+++ b/src/cassandra/schema/function_meta.rs
@@ -113,10 +113,8 @@ impl FunctionMeta {
     /// Gets the function's argument and type for the provided name.
     pub fn argument_type_by_name(&self, name: &str) -> ConstDataType {
         unsafe {
-            ConstDataType(cass_function_meta_argument_type_by_name(self.0,
-                                                                   CString::new(name)
-                                                                       .expect("must be utf8")
-                                                                       .as_ptr()))
+            let name_cstr = CString::new(name).expect("must be utf8");
+            ConstDataType(cass_function_meta_argument_type_by_name(self.0, name_cstr.as_ptr()))
         }
     }
 
@@ -127,7 +125,8 @@ impl FunctionMeta {
     /// access to the column data found in the underlying "functions" metadata table.
     pub fn field_by_name(&self, name: &str) -> Value {
         unsafe {
-            Value::build(cass_function_meta_field_by_name(self.0, CString::new(name).expect("must be utf8").as_ptr()))
+            let name_cstr = CString::new(name).expect("must be utf8");
+            Value::build(cass_function_meta_field_by_name(self.0, name_cstr.as_ptr()))
         }
     }
 }

--- a/src/cassandra/schema/keyspace_meta.rs
+++ b/src/cassandra/schema/keyspace_meta.rs
@@ -54,7 +54,8 @@ impl KeyspaceMeta {
     /// Gets the table metadata for the provided table name.
     pub fn table_by_name(&self, name: &str) -> Option<TableMeta> {
         unsafe {
-            let value = cass_keyspace_meta_table_by_name(self.0, CString::new(name).expect("must be utf8").as_ptr());
+            let name_cstr = CString::new(name).expect("must be utf8");
+            let value = cass_keyspace_meta_table_by_name(self.0, name_cstr.as_ptr());
             if value.is_null() {
                 None
             } else {
@@ -66,8 +67,8 @@ impl KeyspaceMeta {
     /// Gets the data type for the provided type name.
     pub fn user_type_by_name(&self, name: &str) -> Option<ConstDataType> {
         unsafe {
-            let value = cass_keyspace_meta_user_type_by_name(self.0,
-                                                             CString::new(name).expect("must be utf8").as_ptr());
+            let name_cstr = CString::new(name).expect("must be utf8");
+            let value = cass_keyspace_meta_user_type_by_name(self.0, name_cstr.as_ptr());
             if value.is_null() {
                 None
             } else {
@@ -79,11 +80,12 @@ impl KeyspaceMeta {
     /// Gets the function metadata for the provided function name.
     pub fn get_function_by_name(&self, name: &str, arguments: Vec<&str>) -> Option<FunctionMeta> {
         unsafe {
+            let name_cstr = CString::new(name).expect("must be utf8");
+            let arguments_cstr = CString::new(arguments.join(","))
+                .expect("must be utf8");
             let value = cass_keyspace_meta_function_by_name(self.0,
-                                                            CString::new(name).expect("must be utf8").as_ptr(),
-                                                            CString::new(arguments.join(","))
-                                                                .expect("must be utf8")
-                                                                .as_ptr());
+                                                            name_cstr.as_ptr(),
+                                                            arguments_cstr.as_ptr());
             if value.is_null() {
                 None
             } else {
@@ -95,15 +97,15 @@ impl KeyspaceMeta {
     /// Gets the aggregate metadata for the provided aggregate name.
     pub fn aggregate_by_name(&self, name: &str, arguments: Vec<&str>) -> Option<AggregateMeta> {
         unsafe {
+            let name_cstr = CString::new(name).expect("must be utf8");
+            let arguments_cstr = CString::new(arguments.join(",")).expect("must be utf8");
             let agg = cass_keyspace_meta_aggregate_by_name(self.0,
-                                                           CString::new(name).expect("must be utf8").as_ptr(),
-                                                           CString::new(arguments.join(","))
-                                                               .expect("must be utf8")
-                                                               .as_ptr());
+                                                           name_cstr.as_ptr(),
+                                                           arguments_cstr.as_ptr());
             if agg.is_null() {
                 None
             } else {
-                Some(AggregateMeta::build((agg)))
+                Some(AggregateMeta::build(agg))
             }
         }
     }
@@ -137,7 +139,8 @@ impl KeyspaceMeta {
     /// access to the column data found in the underlying "keyspaces" metadata table.
     pub fn field_by_name(&self, name: &str) -> Option<MetadataFieldValue> {
         unsafe {
-            let value = cass_keyspace_meta_field_by_name(self.0, CString::new(name).expect("must be utf8").as_ptr());
+            let name_cstr = CString::new(name).expect("must be utf8");
+            let value = cass_keyspace_meta_field_by_name(self.0, name_cstr.as_ptr());
             if value.is_null() {
                 None
             } else {

--- a/src/cassandra/session.rs
+++ b/src/cassandra/session.rs
@@ -77,7 +77,9 @@ impl Session {
     /// Connects a session and sets the keyspace.
     pub fn connect_keyspace(&self, cluster: &Cluster, keyspace: &str) -> Result<CassFuture<()>> {
         unsafe {
-            Ok(<CassFuture<()>>::build(cass_session_connect_keyspace(self.0, cluster.inner(), CString::new(keyspace)?.as_ptr())))
+            let keyspace_cstr = CString::new(keyspace)?;
+            Ok(<CassFuture<()>>::build(
+                cass_session_connect_keyspace(self.0, cluster.inner(), keyspace_cstr.as_ptr())))
         }
     }
 
@@ -89,7 +91,9 @@ impl Session {
     /// Create a prepared statement.
     pub fn prepare(&self, query: &str) -> Result<CassFuture<PreparedStatement>> {
         unsafe {
-            Ok(<CassFuture<PreparedStatement>>::build(cass_session_prepare(self.0, CString::new(query)?.as_ptr())))
+            let query_cstr = CString::new(query)?;
+            Ok(<CassFuture<PreparedStatement>>::build(
+                cass_session_prepare(self.0, query_cstr.as_ptr())))
         }
     }
 

--- a/src/cassandra/ssl.rs
+++ b/src/cassandra/ssl.rs
@@ -67,7 +67,8 @@ impl Ssl {
     /// the peer's certificate.
     pub fn add_trusted_cert(&mut self, cert: &str) -> Result<&mut Self> {
         unsafe {
-            cass_ssl_add_trusted_cert(self.0, CString::new(cert)?.as_ptr())
+            let cert_cstr = CString::new(cert)?;
+            cass_ssl_add_trusted_cert(self.0, cert_cstr.as_ptr())
                 .to_result(self)
         }
     }
@@ -90,7 +91,8 @@ impl Ssl {
     /// Certificate chain starting with the certificate itself.
     pub fn set_cert(&mut self, cert: &str) -> Result<&mut Self> {
         unsafe {
-            cass_ssl_set_cert(self.0, CString::new(cert)?.as_ptr())
+            let cert_cstr = CString::new(cert)?;
+            cass_ssl_set_cert(self.0, cert_cstr.as_ptr())
                 .to_result(self)
         }
     }
@@ -99,8 +101,9 @@ impl Ssl {
     /// the client on the server-side.
     pub fn set_private_key(&mut self, key: &str, password: &str) -> Result<&mut Self> {
         unsafe {
+            let key_cstr = CString::new(key)?;
             cass_ssl_set_private_key(self.0,
-                                     CString::new(key)?.as_ptr(),
+                                     key_cstr.as_ptr(),
                                      password.as_ptr() as *const i8)
                 .to_result(self)
         }

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -191,7 +191,8 @@ impl Statement {
     /// Creates a new query statement.
     pub fn new(query: &str, parameter_count: usize) -> Self {
         unsafe {
-            Statement(cass_statement_new(CString::new(query).expect("must be utf8").as_ptr(),
+            let query_cstr = CString::new(query).expect("must be utf8");
+            Statement(cass_statement_new(query_cstr.as_ptr(),
                                          parameter_count))
         }
     }
@@ -224,8 +225,9 @@ impl Statement {
     /// is determined in the metadata processed in the prepare phase.
     pub fn set_keyspace(&mut self, keyspace: String) -> Result<&mut Self> {
         unsafe {
+            let keyspace_cstr = CString::new(keyspace)?;
             cass_statement_set_keyspace(self.0,
-                                        (CString::new(keyspace)?.as_ptr()))
+                                        keyspace_cstr.as_ptr())
                 .to_result(self)
         }
     }
@@ -330,7 +332,8 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_null_by_name(&mut self, name: &str) -> Result<&mut Self> {
         unsafe {
-            cass_statement_bind_null_by_name(self.0, CString::new(name)?.as_ptr())
+            let name_cstr = CString::new(name)?;
+            cass_statement_bind_null_by_name(self.0, name_cstr.as_ptr())
                 .to_result(self)
         }
     }
@@ -346,8 +349,9 @@ impl Statement {
     /// Binds a "tinyint" to all the values with the specified name.
     pub fn bind_int8_by_name(&mut self, name: &str, value: i8) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_int8_by_name(self.0,
-                                             CString::new(name)?.as_ptr(),
+                                             name_cstr.as_ptr(),
                                              value)
                 .to_result(self)
         }
@@ -364,8 +368,9 @@ impl Statement {
     /// Binds a "smallint" to all the values with the specified name.
     pub fn bind_int16_by_name(&mut self, name: &str, value: i16) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_int16_by_name(self.0,
-                                              CString::new(name)?.as_ptr(),
+                                              name_cstr.as_ptr(),
                                               value)
                 .to_result(self)
         }
@@ -382,8 +387,9 @@ impl Statement {
     /// Binds an "int" to all the values with the specified name.
     pub fn bind_int32_by_name(&mut self, name: &str, value: i32) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_int32_by_name(self.0,
-                                              CString::new(name)?.as_ptr(),
+                                              name_cstr.as_ptr(),
                                               value)
                 .to_result(self)
         }
@@ -403,8 +409,9 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_uint32_by_name(&mut self, name: &str, value: u32) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_uint32_by_name(self.0,
-                                               CString::new(name)?.as_ptr(),
+                                               name_cstr.as_ptr(),
                                                value)
                 .to_result(self)
         }
@@ -423,8 +430,9 @@ impl Statement {
     /// with the specified name.
     pub fn bind_int64_by_name(&mut self, name: &str, value: i64) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_int64_by_name(self.0,
-                                              CString::new(name)?.as_ptr(),
+                                              name_cstr.as_ptr(),
                                               value)
                 .to_result(self)
         }
@@ -444,8 +452,9 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_float_by_name(&mut self, name: &str, value: f32) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_float_by_name(self.0,
-                                              CString::new(name)?.as_ptr(),
+                                              name_cstr.as_ptr(),
                                               value)
                 .to_result(self)
         }
@@ -465,8 +474,9 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_double_by_name(&mut self, name: &str, value: f64) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_double_by_name(self.0,
-                                               CString::new(name)?.as_ptr(),
+                                               name_cstr.as_ptr(),
                                                value)
                 .to_result(self)
         }
@@ -486,8 +496,9 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_bool_by_name(&mut self, name: &str, value: bool) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_bool_by_name(self.0,
-                                             CString::new(name)?.as_ptr(),
+                                             name_cstr.as_ptr(),
                                              if value { cass_true } else { cass_false })
                 .to_result(self)
         }
@@ -497,9 +508,10 @@ impl Statement {
     /// at the specified index.
     pub fn bind_string(&mut self, index: usize, value: &str) -> Result<&mut Self> {
         unsafe {
+            let value_cstr = CString::new(value)?;
             cass_statement_bind_string(self.0,
                                        index,
-                                       CString::new(value)?.as_ptr())
+                                       value_cstr.as_ptr())
                 .to_result(self)
         }
     }
@@ -511,9 +523,11 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_string_by_name(&mut self, name: &str, value: &str) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
+            let value_cstr = CString::new(value)?;
             cass_statement_bind_string_by_name(self.0,
-                                               CString::new(name)?.as_ptr(),
-                                               CString::new(value)?.as_ptr())
+                                               name_cstr.as_ptr(),
+                                               value_cstr.as_ptr())
                 .to_result(self)
 
         }
@@ -534,8 +548,9 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_bytes_by_name(&mut self, name: &str, mut value: Vec<u8>) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_bytes_by_name(self.0,
-                                              CString::new(name)?.as_ptr(),
+                                              name_cstr.as_ptr(),
                                               value.as_mut_ptr(),
                                               value.len())
                 .to_result(self)
@@ -557,8 +572,9 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_uuid_by_name(&mut self, name: &str, value: Uuid) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_uuid_by_name(self.0,
-                                             CString::new(name)?.as_ptr(),
+                                             name_cstr.as_ptr(),
                                              value.inner())
                 .to_result(self)
         }
@@ -575,8 +591,9 @@ impl Statement {
     /// Binds an "inet" to all the values with the specified name.
     pub fn bind_inet_by_name(&mut self, name: &str, value: Inet) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_inet_by_name(self.0,
-                                             CString::new(name)?.as_ptr(),
+                                             name_cstr.as_ptr(),
                                              value.inner())
                 .to_result(self)
         }
@@ -634,8 +651,9 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_map_by_name(&mut self, name: &str, map: Map) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_collection_by_name(self.0,
-                                                   CString::new(name)?.as_ptr(),
+                                                   name_cstr.as_ptr(),
                                                    map.inner())
                 .to_result(self)
         }
@@ -655,8 +673,9 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_set_by_name(&mut self, name: &str, collection: Set) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_collection_by_name(self.0,
-                                                   CString::new(name)?.as_ptr(),
+                                                   name_cstr.as_ptr(),
                                                    collection.inner())
                 .to_result(self)
         }
@@ -677,8 +696,9 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_list_by_name(&mut self, name: &str, collection: List) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_collection_by_name(self.0,
-                                                   CString::new(name)?.as_ptr(),
+                                                   name_cstr.as_ptr(),
                                                    collection.inner())
                 .to_result(self)
         }
@@ -698,8 +718,9 @@ impl Statement {
     /// cass_prepared_bind().
     pub fn bind_tuple_by_name(&mut self, name: &str, value: Tuple) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_tuple_by_name(self.0,
-                                              CString::new(name)?.as_ptr(),
+                                              name_cstr.as_ptr(),
                                               value.inner())
                 .to_result(self)
         }
@@ -718,8 +739,9 @@ impl Statement {
     /// specified name.
     pub fn bind_user_type_by_name(&mut self, name: &str, value: &UserType) -> Result<&mut Self> {
         unsafe {
+            let name_cstr = CString::new(name)?;
             cass_statement_bind_user_type_by_name(self.0,
-                                                  CString::new(name)?.as_ptr(),
+                                                  name_cstr.as_ptr(),
                                                   value.inner())
                 .to_result(self)
         }

--- a/src/cassandra/tuple.rs
+++ b/src/cassandra/tuple.rs
@@ -137,9 +137,10 @@ impl Tuple {
     pub fn set_string<S>(&mut self, index: usize, value: S) -> Result<&mut Self>
         where S: Into<String> {
         unsafe {
+            let value_cstr = CString::new(value.into())?;
             cass_tuple_set_string(self.0,
                                   index,
-                                  CString::new(value.into())?.as_ptr())
+                                  value_cstr.as_ptr())
                 .to_result(self)
         }
     }

--- a/src/cassandra/user_type.rs
+++ b/src/cassandra/user_type.rs
@@ -91,8 +91,9 @@ impl UserType {
     pub fn set_null_by_name<S>(&mut self, name: S) -> Result<&mut Self>
         where S: Into<String> {
         unsafe {
+            let name_cstr = CString::new(name.into())?;
             cass_user_type_set_null_by_name(self.0,
-                                            CString::new(name.into())?.as_ptr())
+                                            name_cstr.as_ptr())
                 .to_result(self)
         }
     }

--- a/src/cassandra/uuid.rs
+++ b/src/cassandra/uuid.rs
@@ -94,7 +94,8 @@ impl str::FromStr for Uuid {
     fn from_str(str: &str) -> Result<Uuid> {
         unsafe {
             let mut uuid = mem::zeroed();
-            cass_uuid_from_string(CString::new(str)?.as_ptr(), &mut uuid).to_result(())
+            let str_cstr = CString::new(str)?;
+            cass_uuid_from_string(str_cstr.as_ptr(), &mut uuid).to_result(())
                 .and_then(|_| Ok(Uuid(uuid)))
         }
     }


### PR DESCRIPTION
When testing at load we discovered an intermittent `LIB_INDEX_OUT_OF_BOUNDS` errors, which we traced to `get_column_by_name` failing to identify a column which we knew was present in the row. Further investigation revealed that this was a use-after-free error in the unsafe code in this wrapper.

This test fixes the one that caused the problem, and also all other instances of the same pattern: passing `CString::new().as_ptr()` to a C function, which risks it being freed before the function is called. Instead we follow the `CString` docs and bind the `CString` to a local variable first.

Presumably this was exposed by a compiler upgrade.