### PR TITLE
Use absolute path in the stmt macro

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ This file's format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/). The
 version number is tracked in the file `VERSION`.
 
+## [0.13.1] - ???
+- Fix `stmt!()` not working if `Statement` was not imported.
+
 ## [0.13.0] - 2018-12-04
 - Added new set_local_address function using the function Datastax added in
   cassandra-cpp-driver version 2.10.0

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -90,9 +90,9 @@ macro_rules! stmt {
     ( $( $x:expr ),*) => {
         {
             $(
-        	let query = $x;
-        	let param_count = query.matches("?").count();
-        	let statement = Statement::new(query, param_count);
+            let query = $x;
+            let param_count = query.matches("?").count();
+            let statement = $crate::Statement::new(query, param_count);
             )*
             statement
         }
@@ -100,12 +100,12 @@ macro_rules! stmt {
 }
 
 // statement,
-// 	key,
-// 	i % 2 == 0,
-// 	i as f32 / 2.0f32,
-// 	i as f64 / 200.0,
-// 	i as i32 * 10,
-// 	i as i64 * 100);
+//  key,
+//  i % 2 == 0,
+//  i as f32 / 2.0f32,
+//  i as f64 / 200.0,
+//  i as i32 * 10,
+//  i as i64 * 100);
 
 
 impl Drop for Statement {
@@ -600,7 +600,7 @@ impl Statement {
     }
 
 
-    // 	///Bind a "decimal" to a query or bound statement at the specified index.
+    //  ///Bind a "decimal" to a query or bound statement at the specified index.
     //    pub fn bind_decimal(&self,
     //                                index: i32,
     //                                value: d128)


### PR DESCRIPTION
Fixes issues if you try to use the stmt macro without importing the Statement type.

Signed-off-by: Alex Parrill <aparrill@datto.com>