### PR TITLE
Correct drop order for completed futures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ version number is tracked in the file `VERSION`.
 
 ### Fixed
 - `Value::get_inet` which would always return a zeroed `Inet`
+- Dropping futures early could cause a segfault when using the system
+  allocator (in Rust 1.32.0 or later).
 
 ## [0.13.2] - 2019-01-15
 - Avoid possible segfaults, by returning `None` where possible, otherwise

--- a/src/cassandra/future.rs
+++ b/src/cassandra/future.rs
@@ -238,8 +238,10 @@ enum FutureState {
 unsafe extern "C" fn notify_task(_c_future: *mut _Future, data: *mut ::std::os::raw::c_void) {
     let future_target: &FutureTarget = &*(data as *const FutureTarget);
     // The future is now ready, so transition to the appropriate state.
-    let mut lock = future_target.inner.lock().expect("notify_task");
-    let state = mem::replace(&mut *lock, FutureState::Ready);
+    let state = {
+        let mut lock = future_target.inner.lock().expect("notify_task");
+        mem::replace(&mut *lock, FutureState::Ready)
+    };
     if let FutureState::Awaiting { ref task, .. } = state {
         task.notify();
     } else {


### PR DESCRIPTION
The mutex guarding the future state must be unlocked *before* we free it; unlocking it after we free it somehow works with jemallocator but is obviously UB.

Resolves #53.
