### PR TITLE
Fix type signature on set_load_balance_dc_aware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ version number is tracked in the file `VERSION`.
 
 ### Fixed
 - Provide missing doc comment, fix unused doc comment warnings.
+- Fix type signature on `set_load_balance_dc_aware` so it can be used.
 
 ## [0.14.0] - 2019-01-22
 ### Added

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -8,7 +8,6 @@ use cassandra::util::Protected;
 use cassandra::error::*;
 
 use cassandra_sys::CassCluster as _Cluster;
-use cassandra_sys::cass_bool_t;
 use cassandra_sys::cass_cluster_free;
 use cassandra_sys::cass_cluster_new;
 use cassandra_sys::cass_cluster_set_connect_timeout;
@@ -397,7 +396,7 @@ impl Cluster {
     /// query plans. If relying on this mechanism, be sure to use only contact
     /// points from the local DC.
     pub fn set_load_balance_dc_aware<S>(&mut self, local_dc: &str, used_hosts_per_remote_dc: u32,
-        allow_remote_dcs_for_local_cl: cass_bool_t)
+        allow_remote_dcs_for_local_cl: bool)
                                         -> Result<&mut Self> {
         unsafe {
             {
@@ -405,7 +404,7 @@ impl Cluster {
                     cass_cluster_set_load_balance_dc_aware(self.0,
                                                            local_dc.as_ptr(),
                                                            used_hosts_per_remote_dc,
-                                                           allow_remote_dcs_for_local_cl)
+                                                           if allow_remote_dcs_for_local_cl { cass_true } else { cass_false })
                 }
                 .to_result(self)
         }


### PR DESCRIPTION
This used a cassandra-sys type, `cass_bool_t`, which is not exposed to clients. Fix it to use a normal Rust boolean.