### PR TITLE
More ergonomic uuid::Uuid handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ version number is tracked in the file `VERSION`.
 
 ## [Unreleased]
 ### Added
+- Conversion functions between `uuid::Uuid` and this library's `Uuid`.
 ### Changed
 ### Fixed
 

--- a/src/cassandra/row.rs
+++ b/src/cassandra/row.rs
@@ -279,6 +279,21 @@ impl AsRustType<Uuid> for Row {
     }
 }
 
+impl AsRustType<uuid::Uuid> for Row {
+    fn get(&self, index: usize) -> Result<uuid::Uuid> {
+        let col = self.get_column(index)?;
+        col.get_uuid().map(|x| x.into())
+    }
+
+    fn get_by_name<S>(&self, name: S) -> Result<uuid::Uuid>
+    where
+        S: Into<String>,
+    {
+        let col = self.get_column_by_name(name)?;
+        col.get_uuid().map(|x| x.into())
+    }
+}
+
 impl AsRustType<Vec<u8>> for Row {
     fn get(&self, index: usize) -> Result<Vec<u8>> {
         let col = self.get_column(index)?;

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -257,6 +257,16 @@ impl BindRustType<Uuid> for Statement {
     }
 }
 
+impl BindRustType<uuid::Uuid> for Statement {
+    fn bind(&mut self, index: usize, value: uuid::Uuid) -> Result<&mut Self> {
+        self.bind_uuid(index, value.into())
+    }
+
+    fn bind_by_name(&mut self, col: &str, value: uuid::Uuid) -> Result<&mut Self> {
+        self.bind_uuid_by_name(col, value.into())
+    }
+}
+
 impl BindRustType<Inet> for Statement {
     fn bind(&mut self, index: usize, value: Inet) -> Result<&mut Self> {
         self.bind_inet(index, value)

--- a/src/cassandra/uuid.rs
+++ b/src/cassandra/uuid.rs
@@ -104,6 +104,53 @@ impl Uuid {
     }
 }
 
+impl From<uuid::Uuid> for Uuid {
+    fn from(id: uuid::Uuid) -> Uuid {
+        // implementation taken from serializetion.hpp
+        unsafe {
+            let input = id.as_bytes();
+            let mut uuid: _Uuid = mem::zeroed();
+            uuid.time_and_version = input[3] as u64;
+            uuid.time_and_version |= (input[2] as u64) << 8;
+            uuid.time_and_version |= (input[1] as u64) << 16;
+            uuid.time_and_version |= (input[0] as u64) << 24;
+
+            uuid.time_and_version |= (input[5] as u64) << 32;
+            uuid.time_and_version |= (input[4] as u64) << 40;
+
+            uuid.time_and_version |= (input[7] as u64) << 48;
+            uuid.time_and_version |= (input[6] as u64) << 56;
+
+            for i in 0..8 {
+                uuid.clock_seq_and_node |= (input[15 - i] as u64) << (8 * i);
+            }
+            Uuid(uuid)
+        }
+    }
+}
+
+impl Into<uuid::Uuid> for Uuid {
+    fn into(self) -> uuid::Uuid {
+        // implementation taken from serializetion.hpp
+        let mut output = [0u8; 16];
+        output[3] = self.0.time_and_version as u8;
+        output[2] = (self.0.time_and_version >> 8) as u8;
+        output[1] = (self.0.time_and_version >> 16) as u8;
+        output[0] = (self.0.time_and_version >> 24) as u8;
+
+        output[5] = (self.0.time_and_version >> 32) as u8;
+        output[4] = (self.0.time_and_version >> 40) as u8;
+
+        output[7] = (self.0.time_and_version >> 48) as u8;
+        output[6] = (self.0.time_and_version >> 56) as u8;
+
+        for i in 0..8 {
+            output[15 - i] = (self.0.clock_seq_and_node >> (8 * i)) as u8;
+        }
+        uuid::Uuid::from_bytes(&output).unwrap()
+    }
+}
+
 impl str::FromStr for Uuid {
     type Err = Error;
     fn from_str(str: &str) -> Result<Uuid> {

--- a/src/cassandra/uuid.rs
+++ b/src/cassandra/uuid.rs
@@ -106,7 +106,8 @@ impl Uuid {
 
 impl From<uuid::Uuid> for Uuid {
     fn from(id: uuid::Uuid) -> Uuid {
-        // implementation taken from serializetion.hpp encode_uuid()
+        // implementation taken from Datastax C/C++ driver
+        // serialization.hpp, encode_uuid()
         let input = id.as_bytes();
 
         let mut time_and_version = 0u64;
@@ -132,23 +133,24 @@ impl From<uuid::Uuid> for Uuid {
     }
 }
 
-impl Into<uuid::Uuid> for Uuid {
-    fn into(self) -> uuid::Uuid {
-        // implementation taken from serializetion.hpp decode_uuid()
+impl From<Uuid> for uuid::Uuid {
+    fn from(id: Uuid) -> uuid::Uuid {
+        // implementation taken from Datastax C/C++ driver
+        // serialization.hpp decode_uuid()
         let mut output = [0u8; 16];
-        output[3] = self.0.time_and_version as u8;
-        output[2] = (self.0.time_and_version >> 8) as u8;
-        output[1] = (self.0.time_and_version >> 16) as u8;
-        output[0] = (self.0.time_and_version >> 24) as u8;
+        output[3] = id.0.time_and_version as u8;
+        output[2] = (id.0.time_and_version >> 8) as u8;
+        output[1] = (id.0.time_and_version >> 16) as u8;
+        output[0] = (id.0.time_and_version >> 24) as u8;
 
-        output[5] = (self.0.time_and_version >> 32) as u8;
-        output[4] = (self.0.time_and_version >> 40) as u8;
+        output[5] = (id.0.time_and_version >> 32) as u8;
+        output[4] = (id.0.time_and_version >> 40) as u8;
 
-        output[7] = (self.0.time_and_version >> 48) as u8;
-        output[6] = (self.0.time_and_version >> 56) as u8;
+        output[7] = (id.0.time_and_version >> 48) as u8;
+        output[6] = (id.0.time_and_version >> 56) as u8;
 
         for i in 0..8 {
-            output[15 - i] = (self.0.clock_seq_and_node >> (8 * i)) as u8;
+            output[15 - i] = (id.0.clock_seq_and_node >> (8 * i)) as u8;
         }
         uuid::Uuid::from_bytes(&output).unwrap()
     }

--- a/tests/uuids.rs
+++ b/tests/uuids.rs
@@ -1,6 +1,7 @@
 mod help;
 
 use cassandra_cpp::*;
+use std::str::FromStr;
 
 static TRUNCATE_QUERY: &'static str = "TRUNCATE examples.log;";
 static INSERT_QUERY: &'static str = "INSERT INTO examples.log (key, time, entry) VALUES (?, ?, ?);";
@@ -62,4 +63,16 @@ fn test_uuids() {
     let mut uniques = results.iter().map(|ref kv| kv.0).collect::<Vec<Uuid>>();
     uniques.dedup();
     assert_eq!(4, uniques.len());
+}
+
+#[test]
+fn test_uuids_from() {
+    const TEST_UUID: &'static str = "a0a1a2a3-a4a5-a6a7-a8a9-aaabacadaeaf";
+    let uuid_id_from_str = uuid::Uuid::parse_str(TEST_UUID).unwrap();
+    let cass_id_from_str = Uuid::from_str(TEST_UUID).unwrap();
+
+    let cass_id_from_uuid = Uuid::from(uuid_id_from_str);
+    let uuid_id_from_cass: uuid::Uuid = cass_id_from_str.into();
+    assert_eq!(uuid_id_from_str, uuid_id_from_cass);
+    assert_eq!(cass_id_from_str, cass_id_from_uuid);
 }

--- a/tests/uuids.rs
+++ b/tests/uuids.rs
@@ -72,7 +72,7 @@ fn test_uuids_from() {
     let cass_id_from_str = Uuid::from_str(TEST_UUID).unwrap();
 
     let cass_id_from_uuid = Uuid::from(uuid_id_from_str);
-    let uuid_id_from_cass: uuid::Uuid = cass_id_from_str.into();
+    let uuid_id_from_cass = uuid::Uuid::from(cass_id_from_str);
     assert_eq!(uuid_id_from_str, uuid_id_from_cass);
     assert_eq!(cass_id_from_str, cass_id_from_uuid);
 }


### PR DESCRIPTION
This is a more efficient conversion than using strings between `CassUuid` and `Uuid` from the uuid crate. Also added `AsRustType<uuid::Uuid>` and `BindRustType<uuid:Uuid>` impls.
Resolves #56.