### PR TITLE
feat: PreparedStatement is Sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ version number is tracked in the file `VERSION`.
 ## [Unreleased]
 ### Added
 ### Changed
+- `PreparedStatement` is now considered `Sync`, and can be shared across threads.
 ### Fixed
 
 ## [0.15.0] - 2020-01-28

--- a/src/cassandra/prepared.rs
+++ b/src/cassandra/prepared.rs
@@ -17,9 +17,8 @@ use std::{mem, slice, str};
 #[derive(Debug)]
 pub struct PreparedStatement(*const _PreparedStatement);
 
-// The underlying C type has no thread-local state, but does not support access
-// from multiple threads: https://datastax.github.io/cpp-driver/topics/#thread-safety
 unsafe impl Send for PreparedStatement {}
+unsafe impl Sync for PreparedStatement {}
 
 impl Drop for PreparedStatement {
     /// Frees a prepared statement


### PR DESCRIPTION
As per, https://datastax.github.io/cpp-driver/api/struct.CassPrepared/ a PreparedStatement is indeed Sync

> A prepared statement is read-only and it is thread-safe to concurrently bind new statements.


Fixes #72


(We have been running this change-set on prod for a few weeks now with no issue - so it's been empirically proven as well!) 