### PR TITLE
Properly implement paging state tokens.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ version number is tracked in the file `VERSION`.
   requirement that the `CassResult` must live longer than the `Row`.
 
 ### Fixed
+ - `CassResult::set_paging_state_token` was implemented incorrectly, namely, it did nothing,
+   and has instead been replaced with `CassResult::paging_state_token`.
+ - `Statement::set_paging_state_token` has been changed to take a `&[u8]` instead of a `&str`,
+   as a paging state token isn't necessarily utf8 encoded.
 
 ## [0.15.1] - 2020-06-02
 ### Added

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -401,7 +401,7 @@ impl Statement {
     /// <b>Warning:</b> The paging state should not be exposed to or come from
     /// untrusted environments. The paging state could be spoofed and potentially
     /// used to gain access to other data.
-    pub fn set_paging_state_token(&mut self, paging_state: &str) -> Result<&mut Self> {
+    pub fn set_paging_state_token(&mut self, paging_state: &[u8]) -> Result<&mut Self> {
         unsafe {
             cass_statement_set_paging_state_token(
                 self.0,


### PR DESCRIPTION
`CassResult::set_paging_state_token` was simply not correct. It did nothing, and you cannot set a paging state token on a result, only on a statement. 

The underlying c ffi function `cass_result_paging_state_token` *returns* a paging state token by giving you a pointer to its data, and length.

I've modified this function to instead *copy* that value out, and return it as a `Vec<u8>`. I chose this instead of a `String` because, technically, paging state tokens do not have to be utf8 encoded.

In turn, I've also modified `set_paging_state_token` to take a `&[u8]` instead of `&str` to mirror the new implementation of `CassResult::paging_state_token` 


This PR supercedes #81 - which also contains an improper implementation.