### PR TITLE
feat: implement `size_hint` on `ResultIterator`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ version number is tracked in the file `VERSION`.
 - Extended the lifetime of a `CassResult` into a `Row`. This is a breaking
   change, and may require reworking the code to satisfy the lifetime
   requirement that the `CassResult` must live longer than the `Row`.
+- Implemented `size_hint` on `ResultIterator`.
 
 ### Fixed
  - `CassResult::set_paging_state_token` was implemented incorrectly, namely, it did nothing,

--- a/src/cassandra/result.rs
+++ b/src/cassandra/result.rs
@@ -204,7 +204,7 @@ impl<'a> Iterator for ResultIterator<'a> {
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {
-        (self.1, Some(self.1))
+        (0, Some(self.1))
     }
 }
 

--- a/src/cassandra/result.rs
+++ b/src/cassandra/result.rs
@@ -156,22 +156,31 @@ impl CassResult {
             )
             .to_result(())
             .map(|_| {
-                Some(slice::from_raw_parts(token_ptr as *const u8, token_length as usize).to_vec())
-            })
+                    Some(
+                        slice::from_raw_parts(token_ptr as *const u8, token_length as usize)
+                            .to_vec(),
+                    )
+                })
         }
     }
 
     /// Creates a new iterator for the specified result. This can be
     /// used to iterate over rows in the result.
     pub fn iter(&self) -> ResultIterator {
-        unsafe { ResultIterator(cass_iterator_from_result(self.0), PhantomData) }
+        unsafe {
+            ResultIterator(
+                cass_iterator_from_result(self.0),
+                cass_result_row_count(self.0),
+                PhantomData,
+            )
+        }
     }
 }
 
 /// An iterator over the results of a query.
 /// The result holds the data, so it must last for at least the lifetime of the iterator.
 #[derive(Debug)]
-pub struct ResultIterator<'a>(pub *mut _CassIterator, PhantomData<&'a CassResult>);
+pub struct ResultIterator<'a>(pub *mut _CassIterator, usize, PhantomData<&'a CassResult>);
 
 // The underlying C type has no thread-local state, but does not support access
 // from multiple threads: https://datastax.github.io/cpp-driver/topics/#thread-safety
@@ -192,6 +201,10 @@ impl<'a> Iterator for ResultIterator<'a> {
                 cass_true => Some(self.get_row()),
             }
         }
+    }
+
+    fn size_hint(&self) -> (usize, Option<usize>) {
+        (self.1, Some(self.1))
     }
 }
 


### PR DESCRIPTION
we know the row count, so we can implement `size_hint` on `ResultIterator`, which will let various `collect` impl's be slightly more efficient. 