### PR TITLE
feat: use parking_lot::Mutex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ version number is tracked in the file `VERSION`.
 - Extended the lifetime of a `CassResult` into a `Row`. This is a breaking
   change, and may require reworking the code to satisfy the lifetime
   requirement that the `CassResult` must live longer than the `Row`.
+- Switched to using `parking_lot::Mutex` instead of `std::sync::Mutex` for
+  `CassFuture` coordination.
 
 ### Fixed
  - `CassResult::set_paging_state_token` was implemented incorrectly, namely, it did nothing,

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ decimal = "2"
 time = "0.2"
 uuid = "0.8"
 error-chain = "0.12.1"
+parking_lot = "0.11"
 
 [dev-dependencies]
 tokio = { version = "0.2", features = ["rt-core", "macros", "test-util"] }


### PR DESCRIPTION
parking_lot::Mutex is faster than std::sync::Mutex, so let's use it for the critical lock in `CassFuture`.

This section of parking_lot's docs describes the difference: https://docs.rs/parking_lot/0.11.0/parking_lot/type.Mutex.html#differences-from-the-standard-library-mutex