### PR TITLE
rfc: session arc, and implicitly associating a session to the Statement, Prepared Statement & Batch that it created.

### DIFF
--- a/examples/simple.rs
+++ b/examples/simple.rs
@@ -1,24 +1,69 @@
 use cassandra_cpp::*;
 
-fn main() {
-    let query = stmt!("SELECT keyspace_name FROM system_schema.keyspaces;");
-    let col_name = "keyspace_name";
-
+async fn create_session() -> Result<Session> {
     let contact_points = "127.0.0.1";
-
     let mut cluster = Cluster::default();
-    cluster.set_contact_points(contact_points).unwrap();
+    cluster.set_contact_points(contact_points)?;
     cluster.set_load_balance_round_robin();
 
-    match cluster.connect() {
-        Ok(ref mut session) => {
-            let result = session.execute(&query).wait().unwrap();
-            println!("{}", result);
-            for row in result.iter() {
-                let col: String = row.get_by_name(col_name).unwrap();
-                println!("ks name = {}", col);
-            }
-        }
-        err => println!("{:?}", err),
+    cluster.connect().await
+}
+
+async fn execute_statement() -> Result<()> {
+    let session = create_session().await?;
+    let result = session
+        .statement("SELECT keyspace_name FROM system_schema.keyspaces;")
+        .execute()
+        .await?;
+
+    for row in result.iter() {
+        let col: String = row.get_by_name("keyspace_name")?;
+        print!("ks = {}", col);
     }
+
+    Ok(())
+}
+
+async fn execute_prepared_statement() -> Result<()> {
+    let session = create_session().await?;
+    let prepared_statement = session
+        .prepare("SELECT value FROM kv_table WHERE key = ?")
+        .await?;
+
+    let mut statement = prepared_statement.bind();
+    statement.bind_string(0, "key")?;
+
+    let result = statement.execute().await?;
+    for row in result.iter() {
+        let col: String = row.get_by_name("value")?;
+        print!("value = {}", col);
+    }
+
+    Ok(())
+}
+
+async fn execute_batch_statement() -> Result<()> {
+    let session = create_session().await?;
+    let mut batch = session.batch(BatchType::LOGGED);
+    batch.add_statement(session.statement("INSERT INTO kv_table (key, value) VALUES (?, ?)"))?;
+    batch.add_statement(session.statement("INSERT INTO kv_table (key, value) VALUES (?, ?)"))?;
+    batch.add_statement(session.statement("INSERT INTO kv_table (key, value) VALUES (?, ?)"))?;
+    let _result = batch.execute().await?;
+
+    Ok(())
+}
+
+fn assert_send_static_future<F, T>(_: F)
+where
+    F: std::future::Future<Output = T> + Send + 'static,
+{
+}
+
+fn main() {
+    // tokio, et-al expect the future to be send + 'static, this ensures that the operations we do above are
+    // send + static, something that can quickly turn not to be, because of the lower level FFI code, and the await boundaries
+    // of the `async fn`'s within cassandra-rs.
+    assert_send_static_future(execute_prepared_statement());
+    assert_send_static_future(execute_statement());
+    assert_send_static_future(execute_batch_statement());
 }

--- a/src/cassandra/batch.rs
+++ b/src/cassandra/batch.rs
@@ -136,9 +136,12 @@ impl Batch {
     /// Executes this batch.
     pub async fn execute(self) -> Result<CassResult> {
         let (batch, session) = (self.0, self.1);
-        let execute_batch = unsafe { cass_session_execute_batch(session.inner(), batch.inner()) };
-        let fut = <CassFuture<CassResult>>::build(session, execute_batch);
-        fut.await
+        let execute_future = {
+            let execute_batch =
+                unsafe { cass_session_execute_batch(session.inner(), batch.inner()) };
+            CassFuture::build(session, execute_batch)
+        };
+        execute_future.await
     }
 
     /// Sets the batch's consistency level
@@ -171,7 +174,15 @@ impl Batch {
     }
 
     /// Adds a statement to a batch.
-    pub fn add_statement(&mut self, statement: &Statement) -> Result<&Self> {
+    pub fn add_statement(&mut self, statement: Statement) -> Result<&Self> {
+        // If their sessions are not the same, we can reject at this level.
+        if self.session() != statement.session() {
+            return Err(ErrorKind::BatchSessionMismatch(
+                self.session().clone(),
+                statement.session().clone(),
+            )
+            .into());
+        }
         unsafe { cass_batch_add_statement(self.inner(), statement.inner()).to_result(self) }
     }
 }

--- a/src/cassandra/batch.rs
+++ b/src/cassandra/batch.rs
@@ -1,5 +1,3 @@
-use cassandra_cpp_sys::cass_session_execute_batch;
-
 use crate::cassandra::consistency::Consistency;
 use crate::cassandra::error::*;
 use crate::cassandra::policy::retry::RetryPolicy;
@@ -18,6 +16,7 @@ use crate::cassandra_sys::cass_batch_set_timestamp;
 use crate::cassandra_sys::cass_custom_payload_free;
 use crate::cassandra_sys::cass_custom_payload_new;
 use crate::cassandra_sys::cass_custom_payload_set_n;
+use crate::cassandra_sys::cass_session_execute_batch;
 use crate::cassandra_sys::CassBatch as _Batch;
 use crate::cassandra_sys::CassBatchType_;
 use crate::cassandra_sys::CassConsistency;

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -160,20 +160,11 @@ impl Cluster {
         }
     }
 
-    fn connect_inner(&mut self) -> CassFuture<Session> {
+    /// Asynchronously connects to the cassandra cluster
+    pub async fn connect(&mut self) -> Result<Session> {
         let session = Session::new();
         let connect = unsafe { cass_session_connect(session.inner(), self.0) };
-        <CassFuture<Session>>::build(session, connect)
-    }
-
-    /// Performs a blocking call to connect to Cassandra cluster
-    pub fn connect(&mut self) -> Result<Session> {
-        self.connect_inner().wait()
-    }
-
-    /// Asynchronously connects to the cassandra cluster
-    pub async fn connect_async(&mut self) -> Result<Session> {
-        let connect_future = self.connect_inner();
+        let connect_future = <CassFuture<Session>>::build(session, connect);
         connect_future.await
     }
 

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -164,8 +164,10 @@ impl Cluster {
     /// Connects to the cassandra cluster
     pub async fn connect(&mut self) -> Result<Session> {
         let session = Session::new();
-        let connect = unsafe { cass_session_connect(session.inner(), self.0) };
-        let connect_future = CassFuture::build(session, connect);
+        let connect_future = {
+            let connect = unsafe { cass_session_connect(session.inner(), self.0) };
+            CassFuture::build(session, connect)
+        };
         connect_future.await
     }
 

--- a/src/cassandra/collection.rs
+++ b/src/cassandra/collection.rs
@@ -4,7 +4,7 @@ use crate::cassandra::error::*;
 use crate::cassandra::inet::Inet;
 use crate::cassandra::tuple::Tuple;
 use crate::cassandra::user_type::UserType;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::uuid::Uuid;
 
 use crate::cassandra_sys::cass_collection_append_bool;
@@ -119,10 +119,13 @@ pub struct List(*mut _CassCollection);
 // from multiple threads: https://datastax.github.io/cpp-driver/topics/#thread-safety
 unsafe impl Send for List {}
 
-impl Protected<*mut _CassCollection> for List {
+impl ProtectedInner<*mut _CassCollection> for List {
     fn inner(&self) -> *mut _CassCollection {
         self.0
     }
+}
+
+impl Protected<*mut _CassCollection> for List {
     fn build(inner: *mut _CassCollection) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -131,10 +134,13 @@ impl Protected<*mut _CassCollection> for List {
     }
 }
 
-impl Protected<*mut _CassCollection> for Map {
+impl ProtectedInner<*mut _CassCollection> for Map {
     fn inner(&self) -> *mut _CassCollection {
         self.0
     }
+}
+
+impl Protected<*mut _CassCollection> for Map {
     fn build(inner: *mut _CassCollection) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -143,10 +149,13 @@ impl Protected<*mut _CassCollection> for Map {
     }
 }
 
-impl Protected<*mut _CassCollection> for Set {
+impl ProtectedInner<*mut _CassCollection> for Set {
     fn inner(&self) -> *mut _CassCollection {
         self.0
     }
+}
+
+impl Protected<*mut _CassCollection> for Set {
     fn build(inner: *mut _CassCollection) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/data_type.rs
+++ b/src/cassandra/data_type.rs
@@ -1,6 +1,6 @@
 use crate::cassandra::error::*;
 use crate::cassandra::user_type::UserType;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::value::ValueType;
 
 use crate::cassandra_sys::cass_data_sub_type_count;
@@ -40,10 +40,13 @@ pub struct ConstDataType(*const _CassDataType);
 unsafe impl Send for DataType {}
 unsafe impl Send for ConstDataType {}
 
-impl Protected<*mut _CassDataType> for DataType {
+impl ProtectedInner<*mut _CassDataType> for DataType {
     fn inner(&self) -> *mut _CassDataType {
         self.0
     }
+}
+
+impl Protected<*mut _CassDataType> for DataType {
     fn build(inner: *mut _CassDataType) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -52,10 +55,13 @@ impl Protected<*mut _CassDataType> for DataType {
     }
 }
 
-impl Protected<*const _CassDataType> for ConstDataType {
+impl ProtectedInner<*const _CassDataType> for ConstDataType {
     fn inner(&self) -> *const _CassDataType {
         self.0
     }
+}
+
+impl Protected<*const _CassDataType> for ConstDataType {
     fn build(inner: *const _CassDataType) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/error.rs
+++ b/src/cassandra/error.rs
@@ -1,5 +1,5 @@
 use crate::cassandra::consistency::Consistency;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::value::ValueType;
 use crate::cassandra::write_type::WriteType;
 

--- a/src/cassandra/error.rs
+++ b/src/cassandra/error.rs
@@ -20,6 +20,7 @@ use crate::cassandra_sys::{
     cass_error_result_responses_required, cass_error_result_table, cass_error_result_write_type,
 };
 use crate::cassandra_sys::{cass_false, cass_true};
+use crate::Session;
 
 use std::error::Error as IError;
 use std::ffi::{CStr, CString};
@@ -42,6 +43,12 @@ error_chain! {
         CassError(code: CassErrorCode, msg: String) {
             description("Cassandra error")
             display("Cassandra error {:?}: {}", &code, &msg)
+        }
+
+        /// Errors that happen when an invalid session is passed to a batch.
+        BatchSessionMismatch(batch_session: Session, statement_session: Session) {
+            description("Batch cannot add a statement belonging to another session.")
+            display("Batch's session {:?} != {:?}", &batch_session, &statement_session)
         }
 
         /// Cassandra error result with extended information.

--- a/src/cassandra/future.rs
+++ b/src/cassandra/future.rs
@@ -213,14 +213,6 @@ impl<T: Completable> Future for CassFuture<T> {
     }
 }
 
-impl<T: Completable> CassFuture<T> {
-    /// Synchronously executes the CassFuture, blocking until it
-    /// completes.
-    pub fn wait(mut self) -> Result<T> {
-        unsafe { get_completion(self.take_session(), self.inner) }
-    }
-}
-
 /// Extract success or failure from a future.
 ///
 /// This function will block if the future is not yet ready. In order to ensure that this

--- a/src/cassandra/future.rs
+++ b/src/cassandra/future.rs
@@ -1,8 +1,7 @@
-use crate::cassandra::consistency::Consistency;
 use crate::cassandra::error::*;
 use crate::cassandra::prepared::PreparedStatement;
 use crate::cassandra::result::CassResult;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedWithSession};
 use crate::cassandra::write_type::WriteType;
 use crate::cassandra_sys::cass_future_error_code;
 use crate::cassandra_sys::cass_future_error_message;
@@ -16,6 +15,7 @@ use crate::cassandra_sys::CassError_;
 use crate::cassandra_sys::CassFuture as _Future;
 use crate::cassandra_sys::CASS_OK;
 use crate::cassandra_sys::{cass_false, cass_true};
+use crate::{cassandra::consistency::Consistency, Session};
 
 use parking_lot::Mutex;
 
@@ -44,6 +44,9 @@ pub struct CassFuture<T> {
     /// The current state of this future.
     state: Arc<FutureTarget>,
 
+    /// The session the future is being executed upon.
+    session: Option<Session>,
+
     /// Treat as if it contains a T.
     phantom: PhantomData<T>,
 }
@@ -58,6 +61,7 @@ pub struct CassFuture<T> {
 // concurrent access to the value (you can only poll a future once).
 unsafe impl<T> Sync for CassFuture<T> {}
 unsafe impl<T> Send for CassFuture<T> where T: Send {}
+impl<T> Unpin for CassFuture<T> {}
 
 impl<T> CassFuture<T> {
     /// Wrap a Cassandra driver future to make it a proper Rust future.
@@ -65,14 +69,21 @@ impl<T> CassFuture<T> {
     /// When invoking this take care to supply the correct type argument, since it will
     /// be used to control how the result is extracted from the underlying Cassandra
     /// driver future (see `Completable`).
-    pub(crate) fn build(inner: *mut _Future) -> Self {
+    pub(crate) fn build(session: Session, inner: *mut _Future) -> Self {
         CassFuture {
             inner,
+            session: Some(session),
             state: Arc::new(FutureTarget {
                 inner: Mutex::new(FutureState::Created),
             }),
             phantom: PhantomData,
         }
+    }
+
+    fn take_session(&mut self) -> Session {
+        self.session.take().expect(
+            "invariant: could not take session from CassFuture that already has had session taken.",
+        )
     }
 }
 
@@ -95,19 +106,26 @@ where
     Self: Sized,
 {
     /// Extract the result from the future, if present.
-    unsafe fn get(inner: *mut _Future) -> Option<Self>;
+    unsafe fn get(session: Session, inner: *mut _Future) -> Option<Self>;
 }
 
 /// Futures that complete with no value, or report an error.
 impl Completable for () {
-    unsafe fn get(_inner: *mut _Future) -> Option<Self> {
+    unsafe fn get(_session: Session, _inner: *mut _Future) -> Option<Self> {
         Some(())
+    }
+}
+
+/// Futures that completes with just the session.
+impl Completable for Session {
+    unsafe fn get(session: Session, _inner: *mut _Future) -> Option<Self> {
+        Some(session)
     }
 }
 
 /// The mainline case - a CassResult.
 impl Completable for CassResult {
-    unsafe fn get(inner: *mut _Future) -> Option<Self> {
+    unsafe fn get(_session: Session, inner: *mut _Future) -> Option<Self> {
         cass_future_get_result(inner)
             .as_ref()
             .map(|r| CassResult::build(r as *const _))
@@ -116,10 +134,10 @@ impl Completable for CassResult {
 
 /// Futures that complete with a prepared statement.
 impl Completable for PreparedStatement {
-    unsafe fn get(inner: *mut _Future) -> Option<Self> {
+    unsafe fn get(session: Session, inner: *mut _Future) -> Option<Self> {
         cass_future_get_prepared(inner)
             .as_ref()
-            .map(|r| PreparedStatement::build(r as *const _))
+            .map(|r| PreparedStatement::build(r as *const _, session))
     }
 }
 
@@ -127,7 +145,7 @@ impl Completable for PreparedStatement {
 impl<T: Completable> Future for CassFuture<T> {
     type Output = Result<T>;
 
-    fn poll(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Self::Output> {
         let mut install_callback = false;
         let ret = {
             // Perform the following computations under the lock, and then release it.
@@ -150,7 +168,7 @@ impl<T: Completable> Future for CassFuture<T> {
                     // already, complete now without scheduling a callback.
                     if unsafe { cass_future_ready(self.inner) } == cass_true {
                         // Future is ready; wrap success in `Ok(Ready)` or report failure as `Err`.
-                        Poll::Ready(unsafe { get_completion(self.inner) })
+                        Poll::Ready(self.inner)
                     } else {
                         // Future is not ready; park this task and arrange to be called back when
                         // it is.
@@ -174,7 +192,7 @@ impl<T: Completable> Future for CassFuture<T> {
                 }
                 FutureState::Ready => {
                     // Future has been marked ready by callback. Safe to return now.
-                    Poll::Ready(unsafe { get_completion(self.inner) })
+                    Poll::Ready(self.inner)
                 }
             }
         };
@@ -186,15 +204,20 @@ impl<T: Completable> Future for CassFuture<T> {
                 .to_result(())?;
         }
 
-        ret
+        match ret {
+            Poll::Pending => Poll::Pending,
+            Poll::Ready(inner) => {
+                Poll::Ready(unsafe { get_completion(self.take_session(), inner) })
+            }
+        }
     }
 }
 
 impl<T: Completable> CassFuture<T> {
     /// Synchronously executes the CassFuture, blocking until it
     /// completes.
-    pub fn wait(self) -> Result<T> {
-        unsafe { get_completion(self.inner) }
+    pub fn wait(mut self) -> Result<T> {
+        unsafe { get_completion(self.take_session(), self.inner) }
     }
 }
 
@@ -204,12 +227,12 @@ impl<T: Completable> CassFuture<T> {
 /// function will not block, you can check if the future is ready prior to calling this using
 /// `cass_future_ready`. If the future is ready, this function will not block, otherwise
 /// it will block on waiting for the future to become ready.
-unsafe fn get_completion<T: Completable>(inner: *mut _Future) -> Result<T> {
+unsafe fn get_completion<T: Completable>(session: Session, inner: *mut _Future) -> Result<T> {
     // Wrap success in `Ok(Ready)` or report failure as `Err`.
     // This will block if the future is not yet ready.
     let rc = cass_future_error_code(inner);
     match rc {
-        CASS_OK => match Completable::get(inner) {
+        CASS_OK => match Completable::get(session, inner) {
             None => Err(CassErrorCode::LIB_NULL_VALUE.to_error()),
             Some(v) => Ok(v),
         },

--- a/src/cassandra/inet.rs
+++ b/src/cassandra/inet.rs
@@ -1,5 +1,5 @@
 use crate::cassandra::error::*;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra_sys::cass_inet_from_string_n;
 use crate::cassandra_sys::cass_inet_init_v4;
 use crate::cassandra_sys::cass_inet_init_v6;
@@ -36,10 +36,13 @@ impl PartialEq for Inet {
     }
 }
 
-impl Protected<_Inet> for Inet {
+impl ProtectedInner<_Inet> for Inet {
     fn inner(&self) -> _Inet {
         self.0
     }
+}
+
+impl Protected<_Inet> for Inet {
     fn build(inner: _Inet) -> Self {
         Inet(inner)
     }

--- a/src/cassandra/iterator.rs
+++ b/src/cassandra/iterator.rs
@@ -6,7 +6,7 @@ use crate::cassandra::schema::column_meta::ColumnMeta;
 use crate::cassandra::schema::function_meta::FunctionMeta;
 use crate::cassandra::schema::keyspace_meta::KeyspaceMeta;
 use crate::cassandra::schema::table_meta::TableMeta;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::value::Value;
 
 // use cassandra_sys::CassIteratorType as _CassIteratorType;
@@ -234,10 +234,13 @@ impl Iterator for FieldIterator {
 //    }
 // }
 
-impl Protected<*mut _CassIterator> for UserTypeIterator {
+impl ProtectedInner<*mut _CassIterator> for UserTypeIterator {
     fn inner(&self) -> *mut _CassIterator {
         self.0
     }
+}
+
+impl Protected<*mut _CassIterator> for UserTypeIterator {
     fn build(inner: *mut _CassIterator) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -246,10 +249,13 @@ impl Protected<*mut _CassIterator> for UserTypeIterator {
     }
 }
 
-impl Protected<*mut _CassIterator> for AggregateIterator {
+impl ProtectedInner<*mut _CassIterator> for AggregateIterator {
     fn inner(&self) -> *mut _CassIterator {
         self.0
     }
+}
+
+impl Protected<*mut _CassIterator> for AggregateIterator {
     fn build(inner: *mut _CassIterator) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -258,10 +264,13 @@ impl Protected<*mut _CassIterator> for AggregateIterator {
     }
 }
 
-impl Protected<*mut _CassIterator> for FunctionIterator {
+impl ProtectedInner<*mut _CassIterator> for FunctionIterator {
     fn inner(&self) -> *mut _CassIterator {
         self.0
     }
+}
+
+impl Protected<*mut _CassIterator> for FunctionIterator {
     fn build(inner: *mut _CassIterator) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -270,10 +279,13 @@ impl Protected<*mut _CassIterator> for FunctionIterator {
     }
 }
 
-impl Protected<*mut _CassIterator> for KeyspaceIterator {
+impl ProtectedInner<*mut _CassIterator> for KeyspaceIterator {
     fn inner(&self) -> *mut _CassIterator {
         self.0
     }
+}
+
+impl Protected<*mut _CassIterator> for KeyspaceIterator {
     fn build(inner: *mut _CassIterator) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -282,10 +294,12 @@ impl Protected<*mut _CassIterator> for KeyspaceIterator {
     }
 }
 
-impl Protected<*mut _CassIterator> for FieldIterator {
+impl ProtectedInner<*mut _CassIterator> for FieldIterator {
     fn inner(&self) -> *mut _CassIterator {
         self.0
     }
+}
+impl Protected<*mut _CassIterator> for FieldIterator {
     fn build(inner: *mut _CassIterator) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -294,10 +308,13 @@ impl Protected<*mut _CassIterator> for FieldIterator {
     }
 }
 
-impl Protected<*mut _CassIterator> for ColumnIterator {
+impl ProtectedInner<*mut _CassIterator> for ColumnIterator {
     fn inner(&self) -> *mut _CassIterator {
         self.0
     }
+}
+
+impl Protected<*mut _CassIterator> for ColumnIterator {
     fn build(inner: *mut _CassIterator) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -306,10 +323,13 @@ impl Protected<*mut _CassIterator> for ColumnIterator {
     }
 }
 
-impl Protected<*mut _CassIterator> for TableIterator {
+impl ProtectedInner<*mut _CassIterator> for TableIterator {
     fn inner(&self) -> *mut _CassIterator {
         self.0
     }
+}
+
+impl Protected<*mut _CassIterator> for TableIterator {
     fn build(inner: *mut _CassIterator) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -318,10 +338,13 @@ impl Protected<*mut _CassIterator> for TableIterator {
     }
 }
 
-impl Protected<*mut _CassIterator> for MapIterator {
+impl ProtectedInner<*mut _CassIterator> for MapIterator {
     fn inner(&self) -> *mut _CassIterator {
         self.0
     }
+}
+
+impl Protected<*mut _CassIterator> for MapIterator {
     fn build(inner: *mut _CassIterator) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -330,10 +353,13 @@ impl Protected<*mut _CassIterator> for MapIterator {
     }
 }
 
-impl Protected<*mut _CassIterator> for SetIterator {
+impl ProtectedInner<*mut _CassIterator> for SetIterator {
     fn inner(&self) -> *mut _CassIterator {
         self.0
     }
+}
+
+impl Protected<*mut _CassIterator> for SetIterator {
     fn build(inner: *mut _CassIterator) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/log.rs
+++ b/src/cassandra/log.rs
@@ -1,7 +1,7 @@
 use crate::cassandra_sys::CassLogLevel_;
 use crate::cassandra_sys::CassLogMessage;
 // use cassandra_sys::cass_log_cleanup; @deprecated
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::ProtectedInner;
 use crate::cassandra_sys::cass_log_set_callback;
 use crate::cassandra_sys::cass_log_set_level;
 use crate::cassandra_sys::CassLogCallback;

--- a/src/cassandra/policy/retry.rs
+++ b/src/cassandra/policy/retry.rs
@@ -1,4 +1,4 @@
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra_sys::cass_retry_policy_default_new;
 use crate::cassandra_sys::cass_retry_policy_downgrading_consistency_new;
 use crate::cassandra_sys::cass_retry_policy_fallthrough_new;
@@ -14,10 +14,13 @@ pub struct RetryPolicy(*mut _RetryPolicy);
 // from multiple threads: https://datastax.github.io/cpp-driver/topics/#thread-safety
 unsafe impl Send for RetryPolicy {}
 
-impl Protected<*mut _RetryPolicy> for RetryPolicy {
+impl ProtectedInner<*mut _RetryPolicy> for RetryPolicy {
     fn inner(&self) -> *mut _RetryPolicy {
         self.0
     }
+}
+
+impl Protected<*mut _RetryPolicy> for RetryPolicy {
     fn build(inner: *mut _RetryPolicy) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/prepared.rs
+++ b/src/cassandra/prepared.rs
@@ -1,7 +1,7 @@
-use crate::cassandra::data_type::ConstDataType;
 use crate::cassandra::error::*;
 use crate::cassandra::statement::Statement;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner, ProtectedWithSession};
+use crate::{cassandra::data_type::ConstDataType, Session};
 
 use crate::cassandra_sys::cass_prepared_bind;
 use crate::cassandra_sys::cass_prepared_free;
@@ -15,7 +15,7 @@ use std::{mem, slice, str};
 /// A statement that has been prepared against at least one Cassandra node.
 /// Instances of this class should not be created directly, but through Session.prepare().
 #[derive(Debug)]
-pub struct PreparedStatement(*const _PreparedStatement);
+pub struct PreparedStatement(*const _PreparedStatement, Session);
 
 unsafe impl Send for PreparedStatement {}
 unsafe impl Sync for PreparedStatement {}
@@ -29,26 +29,37 @@ impl Drop for PreparedStatement {
     }
 }
 
-impl Protected<*const _PreparedStatement> for PreparedStatement {
+impl ProtectedInner<*const _PreparedStatement> for PreparedStatement {
     fn inner(&self) -> *const _PreparedStatement {
         self.0
     }
-    fn build(inner: *const _PreparedStatement) -> Self {
+}
+
+impl ProtectedWithSession<*const _PreparedStatement> for PreparedStatement {
+    fn build(inner: *const _PreparedStatement, session: Session) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
         };
-        PreparedStatement(inner)
+        PreparedStatement(inner, session)
+    }
+
+    fn inner_session(&self) -> &Session {
+        &self.1
     }
 }
 
 impl PreparedStatement {
     /// Creates a bound statement from a pre-prepared statement.
     pub fn bind(&self) -> Statement {
-        unsafe { Statement::build(cass_prepared_bind(self.0)) }
+        unsafe {
+            Statement::build(
+                cass_prepared_bind(self.inner()),
+                self.inner_session().clone(),
+            )
+        }
     }
 
     /// Gets the name of a parameter at the specified index.
-    #[allow(cast_possible_truncation)]
     pub fn parameter_name(&self, index: usize) -> Result<&str> {
         unsafe {
             let mut name = mem::zeroed();

--- a/src/cassandra/prepared.rs
+++ b/src/cassandra/prepared.rs
@@ -23,19 +23,19 @@ unsafe impl Sync for PreparedStatement {}
 impl Drop for PreparedStatement {
     /// Frees a prepared statement
     fn drop(&mut self) {
-        if !self.0.is_null() {
-            unsafe { cass_prepared_free(self.0) }
-        }
+        unsafe { cass_prepared_free(self.0) }
     }
 }
 
 impl ProtectedInner<*const _PreparedStatement> for PreparedStatement {
+    #[inline(always)]
     fn inner(&self) -> *const _PreparedStatement {
         self.0
     }
 }
 
 impl ProtectedWithSession<*const _PreparedStatement> for PreparedStatement {
+    #[inline(always)]
     fn build(inner: *const _PreparedStatement, session: Session) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
@@ -43,7 +43,8 @@ impl ProtectedWithSession<*const _PreparedStatement> for PreparedStatement {
         PreparedStatement(inner, session)
     }
 
-    fn inner_session(&self) -> &Session {
+    #[inline(always)]
+    fn session(&self) -> &Session {
         &self.1
     }
 }
@@ -51,12 +52,7 @@ impl ProtectedWithSession<*const _PreparedStatement> for PreparedStatement {
 impl PreparedStatement {
     /// Creates a bound statement from a pre-prepared statement.
     pub fn bind(&self) -> Statement {
-        unsafe {
-            Statement::build(
-                cass_prepared_bind(self.inner()),
-                self.inner_session().clone(),
-            )
-        }
+        unsafe { Statement::build(cass_prepared_bind(self.inner()), self.session().clone()) }
     }
 
     /// Gets the name of a parameter at the specified index.

--- a/src/cassandra/result.rs
+++ b/src/cassandra/result.rs
@@ -5,7 +5,7 @@
 use crate::cassandra::data_type::ConstDataType;
 use crate::cassandra::error::*;
 use crate::cassandra::row::Row;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::value::ValueType;
 
 use crate::cassandra_sys::cass_false;
@@ -43,10 +43,13 @@ pub struct CassResult(*const _CassResult);
 unsafe impl Sync for CassResult {}
 unsafe impl Send for CassResult {}
 
-impl Protected<*const _CassResult> for CassResult {
+impl ProtectedInner<*const _CassResult> for CassResult {
     fn inner(&self) -> *const _CassResult {
         self.0
     }
+}
+
+impl Protected<*const _CassResult> for CassResult {
     fn build(inner: *const _CassResult) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/row.rs
+++ b/src/cassandra/row.rs
@@ -3,7 +3,7 @@ use crate::cassandra::error::*;
 use crate::cassandra::inet::Inet;
 use crate::cassandra::iterator::{MapIterator, SetIterator, UserTypeIterator};
 use crate::cassandra::result::CassResult;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::uuid::Uuid;
 use crate::cassandra::value::Value;
 use crate::cassandra_sys::cass_false;
@@ -31,10 +31,13 @@ pub struct Row<'a>(*const _Row, PhantomData<&'a CassResult>);
 unsafe impl<'a> Sync for Row<'a> {}
 unsafe impl<'a> Send for Row<'a> {}
 
-impl<'a> Protected<*const _Row> for Row<'a> {
+impl<'a> ProtectedInner<*const _Row> for Row<'a> {
     fn inner(&self) -> *const _Row {
         self.0
     }
+}
+
+impl<'a> Protected<*const _Row> for Row<'a> {
     fn build(inner: *const _Row) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/schema/aggregate_meta.rs
+++ b/src/cassandra/schema/aggregate_meta.rs
@@ -2,7 +2,7 @@ use crate::cassandra::data_type::ConstDataType;
 use crate::cassandra::iterator::FieldIterator;
 
 use crate::cassandra::schema::function_meta::FunctionMeta;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::value::Value;
 
 use crate::cassandra_sys::cass_aggregate_meta_argument_count;
@@ -25,10 +25,13 @@ use std::os::raw::c_char;
 #[derive(Debug)]
 pub struct AggregateMeta(*const _CassAggregateMeta);
 
-impl Protected<*const _CassAggregateMeta> for AggregateMeta {
+impl ProtectedInner<*const _CassAggregateMeta> for AggregateMeta {
     fn inner(&self) -> *const _CassAggregateMeta {
         self.0
     }
+}
+
+impl Protected<*const _CassAggregateMeta> for AggregateMeta {
     fn build(inner: *const _CassAggregateMeta) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/schema/column_meta.rs
+++ b/src/cassandra/schema/column_meta.rs
@@ -1,7 +1,7 @@
 use crate::cassandra::data_type::ConstDataType;
 
 use crate::cassandra::iterator::FieldIterator;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::value::Value;
 use crate::cassandra_sys::cass_column_meta_data_type;
 use crate::cassandra_sys::cass_column_meta_field_by_name_n;
@@ -20,10 +20,13 @@ use std::os::raw::c_char;
 use std::slice;
 use std::str;
 
-impl Protected<*const _CassColumnMeta> for ColumnMeta {
+impl ProtectedInner<*const _CassColumnMeta> for ColumnMeta {
     fn inner(&self) -> *const _CassColumnMeta {
         self.0
     }
+}
+
+impl Protected<*const _CassColumnMeta> for ColumnMeta {
     fn build(inner: *const _CassColumnMeta) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/schema/function_meta.rs
+++ b/src/cassandra/schema/function_meta.rs
@@ -1,7 +1,7 @@
 use crate::cassandra::data_type::ConstDataType;
 use crate::cassandra::error::*;
 use crate::cassandra::iterator::FieldIterator;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::value::Value;
 
 use crate::cassandra_sys::cass_function_meta_argument;
@@ -26,10 +26,13 @@ use std::{mem, slice, str};
 #[derive(Debug)]
 pub struct FunctionMeta(*const _CassFunctionMeta);
 
-impl Protected<*const _CassFunctionMeta> for FunctionMeta {
+impl ProtectedInner<*const _CassFunctionMeta> for FunctionMeta {
     fn inner(&self) -> *const _CassFunctionMeta {
         self.0
     }
+}
+
+impl Protected<*const _CassFunctionMeta> for FunctionMeta {
     fn build(inner: *const _CassFunctionMeta) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/schema/keyspace_meta.rs
+++ b/src/cassandra/schema/keyspace_meta.rs
@@ -8,7 +8,7 @@ use crate::cassandra::schema::aggregate_meta::AggregateMeta;
 
 use crate::cassandra::schema::function_meta::FunctionMeta;
 use crate::cassandra::schema::table_meta::TableMeta;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 
 use crate::cassandra_sys::cass_iterator_aggregates_from_keyspace_meta;
 use crate::cassandra_sys::cass_iterator_fields_from_keyspace_meta;
@@ -32,10 +32,13 @@ use std::os::raw::c_char;
 #[derive(Debug)]
 pub struct KeyspaceMeta(*const _CassKeyspaceMeta);
 
-impl Protected<*const _CassKeyspaceMeta> for KeyspaceMeta {
+impl ProtectedInner<*const _CassKeyspaceMeta> for KeyspaceMeta {
     fn inner(&self) -> *const _CassKeyspaceMeta {
         self.0
     }
+}
+
+impl Protected<*const _CassKeyspaceMeta> for KeyspaceMeta {
     fn build(inner: *const _CassKeyspaceMeta) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/schema/schema_meta.rs
+++ b/src/cassandra/schema/schema_meta.rs
@@ -1,7 +1,7 @@
 use crate::cassandra::iterator::KeyspaceIterator;
 
 use crate::cassandra::schema::keyspace_meta::KeyspaceMeta;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra_sys::cass_iterator_keyspaces_from_schema_meta;
 use crate::cassandra_sys::cass_schema_meta_free;
 use crate::cassandra_sys::cass_schema_meta_keyspace_by_name_n;
@@ -21,10 +21,13 @@ impl Drop for SchemaMeta {
     }
 }
 
-impl Protected<*const _CassSchemaMeta> for SchemaMeta {
+impl ProtectedInner<*const _CassSchemaMeta> for SchemaMeta {
     fn inner(&self) -> *const _CassSchemaMeta {
         self.0
     }
+}
+
+impl Protected<*const _CassSchemaMeta> for SchemaMeta {
     fn build(inner: *const _CassSchemaMeta) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/schema/table_meta.rs
+++ b/src/cassandra/schema/table_meta.rs
@@ -2,7 +2,7 @@ use crate::cassandra::iterator::ColumnIterator;
 use crate::cassandra::iterator::FieldIterator;
 
 use crate::cassandra::schema::column_meta::ColumnMeta;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::value::Value;
 use crate::cassandra_sys::cass_iterator_columns_from_table_meta;
 use crate::cassandra_sys::cass_iterator_fields_from_table_meta;
@@ -25,10 +25,13 @@ use std::str;
 #[derive(Debug)]
 pub struct TableMeta(*const _CassTableMeta);
 
-impl Protected<*const _CassTableMeta> for TableMeta {
+impl ProtectedInner<*const _CassTableMeta> for TableMeta {
     fn inner(&self) -> *const _CassTableMeta {
         self.0
     }
+}
+
+impl Protected<*const _CassTableMeta> for TableMeta {
     fn build(inner: *const _CassTableMeta) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/session.rs
+++ b/src/cassandra/session.rs
@@ -2,7 +2,6 @@
 #![allow(dead_code)]
 #![allow(missing_copy_implementations)]
 
-use crate::cassandra::batch::Batch;
 use crate::cassandra::cluster::Cluster;
 use crate::cassandra::error::*;
 use crate::cassandra::future::CassFuture;
@@ -11,7 +10,8 @@ use crate::cassandra::prepared::PreparedStatement;
 use crate::cassandra::result::CassResult;
 use crate::cassandra::schema::schema_meta::SchemaMeta;
 use crate::cassandra::statement::Statement;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
+use crate::{cassandra::batch::Batch, BatchType};
 
 use crate::cassandra_sys::cass_session_close;
 use crate::cassandra_sys::cass_session_connect;
@@ -28,6 +28,21 @@ use crate::cassandra_sys::CassSession as _Session;
 use std::ffi::NulError;
 use std::mem;
 use std::os::raw::c_char;
+use std::sync::Arc;
+
+#[derive(Debug)]
+struct SessionInner(*mut _Session);
+
+// The underlying C type has no thread-local state, and explicitly supports access
+// from multiple threads: https://datastax.github.io/cpp-driver/topics/#thread-safety
+unsafe impl Send for SessionInner {}
+unsafe impl Sync for SessionInner {}
+
+impl SessionInner {
+    fn new(inner: *mut _Session) -> Arc<Self> {
+        Arc::new(Self(inner))
+    }
+}
 
 /// A session object is used to execute queries and maintains cluster state through
 /// the control connection. The control connection is used to auto-discover nodes and
@@ -35,27 +50,31 @@ use std::os::raw::c_char;
 /// /pools of connections to cluster nodes which are used to query the cluster.
 ///
 /// Instances of the session object are thread-safe to execute queries.
-#[derive(Debug)]
-pub struct Session(pub *mut _Session);
+#[derive(Debug, Clone)]
+pub struct Session(Arc<SessionInner>);
 
-// The underlying C type has no thread-local state, and explicitly supports access
-// from multiple threads: https://datastax.github.io/cpp-driver/topics/#thread-safety
-unsafe impl Send for Session {}
-unsafe impl Sync for Session {}
-
-impl Protected<*mut _Session> for Session {
+impl ProtectedInner<*mut _Session> for SessionInner {
     fn inner(&self) -> *mut _Session {
         self.0
     }
+}
+
+impl ProtectedInner<*mut _Session> for Session {
+    fn inner(&self) -> *mut _Session {
+        self.0.inner()
+    }
+}
+
+impl Protected<*mut _Session> for Session {
     fn build(inner: *mut _Session) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
         };
-        Session(inner)
+        Session(SessionInner::new(inner))
     }
 }
 
-impl Drop for Session {
+impl Drop for SessionInner {
     /// Frees a session instance. If the session is still connected it will be synchronously
     /// closed before being deallocated.
     fn drop(&mut self) {
@@ -73,36 +92,37 @@ impl Session {
     /// Create a new Cassanda session.
     /// It's recommended to use Cluster.connect() instead
     pub fn new() -> Session {
-        unsafe { Session(cass_session_new()) }
+        unsafe { Session(SessionInner::new(cass_session_new())) }
     }
 
-    //    pub fn new2() -> *mut _Session {
-    //        unsafe { cass_session_new() }
-    //    }
-
     /// Connects a session.
-    pub fn connect(self, cluster: &Cluster) -> CassFuture<()> {
-        unsafe { <CassFuture<()>>::build(cass_session_connect(self.0, cluster.inner())) }
+    pub fn connect(self, cluster: &Cluster) -> CassFuture<Self> {
+        let connect = unsafe { cass_session_connect(self.inner(), cluster.inner()) };
+        <CassFuture<Self>>::build(self, connect)
     }
 
     /// Connects a session and sets the keyspace.
-    pub fn connect_keyspace(&self, cluster: &Cluster, keyspace: &str) -> Result<CassFuture<()>> {
-        unsafe {
+    pub fn connect_keyspace(self, cluster: &Cluster, keyspace: &str) -> Result<CassFuture<Self>> {
+        let connect_keyspace = unsafe {
             let keyspace_ptr = keyspace.as_ptr() as *const c_char;
-            Ok(<CassFuture<()>>::build(cass_session_connect_keyspace_n(
-                self.0,
+            cass_session_connect_keyspace_n(
+                self.inner(),
                 cluster.inner(),
                 keyspace_ptr,
                 keyspace.len(),
-            )))
-        }
+            )
+        };
+        Ok(<CassFuture<Self>>::build(self, connect_keyspace))
     }
 
     /// Closes the session instance, outputs a close future which can
     /// be used to determine when the session has been terminated. This allows
     /// in-flight requests to finish.
     pub fn close(self) -> CassFuture<()> {
-        unsafe { <CassFuture<()>>::build(cass_session_close(self.0)) }
+        unsafe {
+            let close = cass_session_close(self.inner());
+            <CassFuture<()>>::build(self, close)
+        }
     }
 
     /// Create a prepared statement.
@@ -110,7 +130,8 @@ impl Session {
         unsafe {
             let query_ptr = query.as_ptr() as *const c_char;
             Ok(<CassFuture<PreparedStatement>>::build(
-                cass_session_prepare_n(self.0, query_ptr, query.len()),
+                self.clone(),
+                cass_session_prepare_n(self.inner(), query_ptr, query.len()),
             ))
         }
     }
@@ -123,16 +144,9 @@ impl Session {
     //        }
     //    }
 
-    /// Execute a batch statement.
-    pub fn execute_batch(&self, batch: Batch) -> CassFuture<CassResult> {
-        <CassFuture<CassResult>>::build(unsafe {
-            cass_session_execute_batch(self.0, batch.inner())
-        })
-    }
-
-    /// Execute a statement.
-    pub fn execute(&self, statement: &Statement) -> CassFuture<CassResult> {
-        unsafe { <CassFuture<CassResult>>::build(cass_session_execute(self.0, statement.inner())) }
+    /// Creates a new batch that is bound to this session.
+    pub fn batch(&self, batch_type: BatchType) -> Batch {
+        Batch::new(batch_type, self.clone())
     }
 
     /// Gets a snapshot of this session's schema metadata. The returned
@@ -140,14 +154,14 @@ impl Session {
     /// must be called again to retrieve any schema changes since the
     /// previous call.
     pub fn get_schema_meta(&self) -> SchemaMeta {
-        unsafe { SchemaMeta::build(cass_session_get_schema_meta(self.0)) }
+        unsafe { SchemaMeta::build(cass_session_get_schema_meta(self.inner())) }
     }
 
     /// Gets a copy of this session's performance/diagnostic metrics.
     pub fn get_metrics(&self) -> SessionMetrics {
         unsafe {
             let mut metrics = mem::zeroed();
-            cass_session_get_metrics(self.0, &mut metrics);
+            cass_session_get_metrics(self.inner(), &mut metrics);
             SessionMetrics::build(&metrics)
         }
     }

--- a/src/cassandra/ssl.rs
+++ b/src/cassandra/ssl.rs
@@ -1,5 +1,5 @@
 use crate::cassandra::error::*;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 
 use crate::cassandra_sys::cass_ssl_add_trusted_cert_n;
 use crate::cassandra_sys::cass_ssl_free;
@@ -46,10 +46,13 @@ pub struct Ssl(*mut _Ssl);
 // from multiple threads: https://datastax.github.io/cpp-driver/topics/#thread-safety
 unsafe impl Send for Ssl {}
 
-impl Protected<*mut _Ssl> for Ssl {
+impl ProtectedInner<*mut _Ssl> for Ssl {
     fn inner(&self) -> *mut _Ssl {
         self.0
     }
+}
+
+impl Protected<*mut _Ssl> for Ssl {
     fn build(inner: *mut _Ssl) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -10,8 +10,9 @@ use crate::cassandra::policy::retry::RetryPolicy;
 use crate::cassandra::result::CassResult;
 use crate::cassandra::tuple::Tuple;
 use crate::cassandra::user_type::UserType;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{ProtectedInner, ProtectedWithSession};
 use crate::cassandra::uuid::Uuid;
+use crate::{CassFuture, Session};
 
 use crate::cassandra_sys::cass_false;
 use crate::cassandra_sys::cass_statement_add_key_index;
@@ -65,8 +66,13 @@ use crate::cassandra_sys::cass_true;
 use crate::cassandra_sys::CassStatement as _Statement;
 use crate::cassandra_sys::CASS_UINT64_MAX;
 
+use cassandra_cpp_sys::cass_session_execute;
 use std::os::raw::c_char;
 use time::Duration;
+
+#[derive(Debug)]
+struct StatementInner(*mut _Statement);
+
 /// A statement object is an executable query. It represents either a regular
 /// (adhoc) statement or a prepared statement. It maintains the queries' parameter
 /// values along with query options (consistency level, paging state, etc.)
@@ -74,21 +80,34 @@ use time::Duration;
 /// <b>Note:</b> Parameters for regular queries are not supported by the binary protocol
 /// version 1.
 #[derive(Debug)]
-pub struct Statement(*mut _Statement);
+pub struct Statement(StatementInner, Session);
 
 // The underlying C type has no thread-local state, but does not support access
 // from multiple threads: https://datastax.github.io/cpp-driver/topics/#thread-safety
-unsafe impl Send for Statement {}
+unsafe impl Send for StatementInner {}
 
-impl Protected<*mut _Statement> for Statement {
+impl ProtectedInner<*mut _Statement> for StatementInner {
     fn inner(&self) -> *mut _Statement {
         self.0
     }
-    fn build(inner: *mut _Statement) -> Self {
+}
+
+impl ProtectedInner<*mut _Statement> for Statement {
+    fn inner(&self) -> *mut _Statement {
+        self.0.inner()
+    }
+}
+
+impl ProtectedWithSession<*mut _Statement> for Statement {
+    fn build(inner: *mut _Statement, session: Session) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")
         };
-        Statement(inner)
+        Statement(StatementInner(inner), session)
+    }
+
+    fn inner_session(&self) -> &Session {
+        &self.1
     }
 }
 
@@ -96,12 +115,12 @@ impl Protected<*mut _Statement> for Statement {
 /// Create a Statement from a query string, automatically counting `?`
 /// characters to determine the number of parameters.
 macro_rules! stmt {
-    ( $( $x:expr ),*) => {
+    ($statement: expr, $( $x:expr ),*) => {
         {
             $(
             let query = $x;
             let param_count = query.matches("?").count();
-            let statement = $crate::Statement::new(query, param_count);
+            let statement = $crate::Statement::new($statement, query, param_count);
             )*
             statement
         }
@@ -116,11 +135,11 @@ macro_rules! stmt {
 //  i as i32 * 10,
 //  i as i64 * 100);
 
-impl Drop for Statement {
+impl Drop for StatementInner {
     /// Frees a statement instance. Statements can be immediately freed after
     /// being prepared, executed or added to a batch.
     fn drop(&mut self) {
-        unsafe { self.free() }
+        unsafe { cass_statement_free(self.0) }
     }
 }
 
@@ -319,19 +338,26 @@ impl BindRustType<Vec<u8>> for Statement {
 
 impl Statement {
     /// Creates a new query statement.
-    pub fn new(query: &str, parameter_count: usize) -> Self {
+    pub fn new(session: Session, query: &str, parameter_count: usize) -> Self {
         unsafe {
             let query_ptr = query.as_ptr() as *const c_char;
-            Statement(cass_statement_new_n(
-                query_ptr,
-                query.len(),
-                parameter_count,
-            ))
+            Statement(
+                StatementInner(cass_statement_new_n(
+                    query_ptr,
+                    query.len(),
+                    parameter_count,
+                )),
+                session,
+            )
         }
     }
 
-    unsafe fn free(&mut self) {
-        cass_statement_free(self.0)
+    /// Executes the statement.
+    pub async fn execute(self) -> Result<CassResult> {
+        let (statement, session) = (self.0, self.1);
+        let execute = unsafe { cass_session_execute(session.inner(), statement.inner()) };
+        let fut = <CassFuture<CassResult>>::build(session, execute);
+        fut.await
     }
 
     //    ///Binds an arbitrary CassBindable type to a cassandra statement
@@ -351,7 +377,7 @@ impl Statement {
     /// This is not necessary for prepared statements, as the key
     /// parameters are determined in the metadata processed in the prepare phase.
     pub fn add_key_index(&mut self, index: usize) -> Result<&mut Self> {
-        unsafe { cass_statement_add_key_index(self.0, index).to_result(self) }
+        unsafe { cass_statement_add_key_index(self.inner(), index).to_result(self) }
     }
 
     /// Sets the statement's keyspace for use with token-aware routing.
@@ -361,7 +387,8 @@ impl Statement {
     pub fn set_keyspace(&mut self, keyspace: String) -> Result<&mut Self> {
         unsafe {
             let keyspace_ptr = keyspace.as_ptr() as *const c_char;
-            cass_statement_set_keyspace_n(self.0, keyspace_ptr, keyspace.len()).to_result(self)
+            cass_statement_set_keyspace_n(self.inner(), keyspace_ptr, keyspace.len())
+                .to_result(self)
         }
     }
 
@@ -369,7 +396,7 @@ impl Statement {
     ///
     /// <b>Default:</b> CASS_CONSISTENCY_LOCAL_ONE
     pub fn set_consistency(&mut self, consistency: Consistency) -> Result<&mut Self> {
-        unsafe { cass_statement_set_consistency(self.0, consistency.inner()).to_result(self) }
+        unsafe { cass_statement_set_consistency(self.inner(), consistency.inner()).to_result(self) }
     }
 
     /// Sets the statement's serial consistency level.
@@ -377,7 +404,7 @@ impl Statement {
     /// <b>Default:</b> Not set
     pub fn set_serial_consistency(&mut self, serial_consistency: Consistency) -> Result<&mut Self> {
         unsafe {
-            cass_statement_set_serial_consistency(self.0, serial_consistency.inner())
+            cass_statement_set_serial_consistency(self.inner(), serial_consistency.inner())
                 .to_result(self)
         }
     }
@@ -386,13 +413,13 @@ impl Statement {
     ///
     /// <b>Default:</b> -1 (Disabled)
     pub fn set_paging_size(&mut self, page_size: i32) -> Result<&mut Self> {
-        unsafe { cass_statement_set_paging_size(self.0, page_size).to_result(self) }
+        unsafe { cass_statement_set_paging_size(self.inner(), page_size).to_result(self) }
     }
 
     /// Sets the statement's paging state. This can be used to get the next page of
     /// data in a multi-page query.
     pub fn set_paging_state(&mut self, result: CassResult) -> Result<&mut Self> {
-        unsafe { cass_statement_set_paging_state(self.0, result.inner()).to_result(self) }
+        unsafe { cass_statement_set_paging_state(self.inner(), result.inner()).to_result(self) }
     }
 
     /// Sets the statement's paging state.  This can be used to get the next page of
@@ -404,7 +431,7 @@ impl Statement {
     pub fn set_paging_state_token(&mut self, paging_state: &[u8]) -> Result<&mut Self> {
         unsafe {
             cass_statement_set_paging_state_token(
-                self.0,
+                self.inner(),
                 paging_state.as_ptr() as *const i8,
                 paging_state.len(),
             )
@@ -414,7 +441,7 @@ impl Statement {
 
     /// Sets the statement's timestamp.
     pub fn set_timestamp(&mut self, timestamp: i64) -> Result<&mut Self> {
-        unsafe { cass_statement_set_timestamp(self.0, timestamp).to_result(self) }
+        unsafe { cass_statement_set_timestamp(self.inner(), timestamp).to_result(self) }
     }
 
     /// Sets the statement's timeout for waiting for a response from a node.
@@ -426,24 +453,26 @@ impl Statement {
                 None => CASS_UINT64_MAX as u64,
                 Some(time) => time.num_milliseconds() as u64,
             };
-            cass_statement_set_request_timeout(self.0, timeout_millis);
+            cass_statement_set_request_timeout(self.inner(), timeout_millis);
         }
         self
     }
 
     /// Sets the statement's retry policy.
     pub fn set_retry_policy(&mut self, retry_policy: RetryPolicy) -> Result<&mut Self> {
-        unsafe { cass_statement_set_retry_policy(self.0, retry_policy.inner()).to_result(self) }
+        unsafe {
+            cass_statement_set_retry_policy(self.inner(), retry_policy.inner()).to_result(self)
+        }
     }
 
     /// Sets the statement's custom payload.
     pub fn set_custom_payload(&mut self, payload: CustomPayload) -> Result<&mut Self> {
-        unsafe { cass_statement_set_custom_payload(self.0, payload.inner()).to_result(self) }
+        unsafe { cass_statement_set_custom_payload(self.inner(), payload.inner()).to_result(self) }
     }
 
     /// Binds null to a query or bound statement at the specified index.
     pub fn bind_null(&mut self, index: usize) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_null(self.0, index).to_result(self) }
+        unsafe { cass_statement_bind_null(self.inner(), index).to_result(self) }
     }
 
     /// Binds a null to all the values with the specified name.
@@ -453,52 +482,55 @@ impl Statement {
     pub fn bind_null_by_name(&mut self, name: &str) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_null_by_name_n(self.0, name_ptr, name.len()).to_result(self)
+            cass_statement_bind_null_by_name_n(self.inner(), name_ptr, name.len()).to_result(self)
         }
     }
 
     /// Binds a "tinyint" to a query or bound statement at the specified index.
     pub fn bind_int8(&mut self, index: usize, value: i8) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_int8(self.0, index, value).to_result(self) }
+        unsafe { cass_statement_bind_int8(self.inner(), index, value).to_result(self) }
     }
 
     /// Binds a "tinyint" to all the values with the specified name.
     pub fn bind_int8_by_name(&mut self, name: &str, value: i8) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_int8_by_name_n(self.0, name_ptr, name.len(), value).to_result(self)
+            cass_statement_bind_int8_by_name_n(self.inner(), name_ptr, name.len(), value)
+                .to_result(self)
         }
     }
 
     /// Binds an "smallint" to a query or bound statement at the specified index.
     pub fn bind_int16(&mut self, index: usize, value: i16) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_int16(self.0, index, value).to_result(self) }
+        unsafe { cass_statement_bind_int16(self.inner(), index, value).to_result(self) }
     }
 
     /// Binds a "smallint" to all the values with the specified name.
     pub fn bind_int16_by_name(&mut self, name: &str, value: i16) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_int16_by_name_n(self.0, name_ptr, name.len(), value).to_result(self)
+            cass_statement_bind_int16_by_name_n(self.inner(), name_ptr, name.len(), value)
+                .to_result(self)
         }
     }
 
     /// Binds an "int" to a query or bound statement at the specified index.
     pub fn bind_int32(&mut self, index: usize, value: i32) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_int32(self.0, index, value).to_result(self) }
+        unsafe { cass_statement_bind_int32(self.inner(), index, value).to_result(self) }
     }
 
     /// Binds an "int" to all the values with the specified name.
     pub fn bind_int32_by_name(&mut self, name: &str, value: i32) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_int32_by_name_n(self.0, name_ptr, name.len(), value).to_result(self)
+            cass_statement_bind_int32_by_name_n(self.inner(), name_ptr, name.len(), value)
+                .to_result(self)
         }
     }
 
     /// Binds a "date" to a query or bound statement at the specified index.
     pub fn bind_uint32(&mut self, index: usize, value: u32) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_uint32(self.0, index, value).to_result(self) }
+        unsafe { cass_statement_bind_uint32(self.inner(), index, value).to_result(self) }
     }
 
     /// Binds a "date" to all the values with the specified name.
@@ -508,7 +540,7 @@ impl Statement {
     pub fn bind_uint32_by_name(&mut self, name: &str, value: u32) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_uint32_by_name_n(self.0, name_ptr, name.len(), value)
+            cass_statement_bind_uint32_by_name_n(self.inner(), name_ptr, name.len(), value)
                 .to_result(self)
         }
     }
@@ -516,7 +548,7 @@ impl Statement {
     /// Binds a "bigint", "counter", "timestamp" or "time" to a query or
     /// bound statement at the specified index.
     pub fn bind_int64(&mut self, index: usize, value: i64) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_int64(self.0, index, value).to_result(self) }
+        unsafe { cass_statement_bind_int64(self.inner(), index, value).to_result(self) }
     }
 
     /// Binds a "bigint", "counter", "timestamp" or "time" to all values
@@ -524,13 +556,14 @@ impl Statement {
     pub fn bind_int64_by_name(&mut self, name: &str, value: i64) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_int64_by_name_n(self.0, name_ptr, name.len(), value).to_result(self)
+            cass_statement_bind_int64_by_name_n(self.inner(), name_ptr, name.len(), value)
+                .to_result(self)
         }
     }
 
     /// Binds a "float" to a query or bound statement at the specified index.
     pub fn bind_float(&mut self, index: usize, value: f32) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_float(self.0, index, value).to_result(self) }
+        unsafe { cass_statement_bind_float(self.inner(), index, value).to_result(self) }
     }
 
     /// Binds a "float" to all the values with the specified name.
@@ -540,13 +573,14 @@ impl Statement {
     pub fn bind_float_by_name(&mut self, name: &str, value: f32) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_float_by_name_n(self.0, name_ptr, name.len(), value).to_result(self)
+            cass_statement_bind_float_by_name_n(self.inner(), name_ptr, name.len(), value)
+                .to_result(self)
         }
     }
 
     /// Binds a "double" to a query or bound statement at the specified index.
     pub fn bind_double(&mut self, index: usize, value: f64) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_double(self.0, index, value).to_result(self) }
+        unsafe { cass_statement_bind_double(self.inner(), index, value).to_result(self) }
     }
 
     /// Binds a "double" to all the values with the specified name.
@@ -556,7 +590,7 @@ impl Statement {
     pub fn bind_double_by_name(&mut self, name: &str, value: f64) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_double_by_name_n(self.0, name_ptr, name.len(), value)
+            cass_statement_bind_double_by_name_n(self.inner(), name_ptr, name.len(), value)
                 .to_result(self)
         }
     }
@@ -564,8 +598,12 @@ impl Statement {
     /// Binds a "boolean" to a query or bound statement at the specified index.
     pub fn bind_bool(&mut self, index: usize, value: bool) -> Result<&mut Self> {
         unsafe {
-            cass_statement_bind_bool(self.0, index, if value { cass_true } else { cass_false })
-                .to_result(self)
+            cass_statement_bind_bool(
+                self.inner(),
+                index,
+                if value { cass_true } else { cass_false },
+            )
+            .to_result(self)
         }
     }
 
@@ -577,7 +615,7 @@ impl Statement {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_bool_by_name_n(
-                self.0,
+                self.inner(),
                 name_ptr,
                 name.len(),
                 if value { cass_true } else { cass_false },
@@ -591,7 +629,8 @@ impl Statement {
     pub fn bind_string(&mut self, index: usize, value: &str) -> Result<&mut Self> {
         unsafe {
             let value_ptr = value.as_ptr() as *const c_char;
-            cass_statement_bind_string_n(self.0, index, value_ptr, value.len()).to_result(self)
+            cass_statement_bind_string_n(self.inner(), index, value_ptr, value.len())
+                .to_result(self)
         }
     }
 
@@ -610,7 +649,7 @@ impl Statement {
             let value_cstr = std::ffi::CString::new(value)?;
 
             cass_statement_bind_string_by_name_n(
-                self.0,
+                self.inner(),
                 name_ptr,
                 name.len(),
                 value_cstr.as_ptr(),
@@ -623,7 +662,8 @@ impl Statement {
     /// Binds a "blob", "varint" or "custom" to a query or bound statement at the specified index.
     pub fn bind_bytes(&mut self, index: usize, value: Vec<u8>) -> Result<&mut Self> {
         unsafe {
-            cass_statement_bind_bytes(self.0, index, value.as_ptr(), value.len()).to_result(self)
+            cass_statement_bind_bytes(self.inner(), index, value.as_ptr(), value.len())
+                .to_result(self)
         }
     }
 
@@ -636,7 +676,7 @@ impl Statement {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_bytes_by_name_n(
-                self.0,
+                self.inner(),
                 name_ptr,
                 name.len(),
                 value.as_mut_ptr(),
@@ -648,7 +688,7 @@ impl Statement {
 
     /// Binds a "uuid" or "timeuuid" to a query or bound statement at the specified index.
     pub fn bind_uuid(&mut self, index: usize, value: Uuid) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_uuid(self.0, index, value.inner()).to_result(self) }
+        unsafe { cass_statement_bind_uuid(self.inner(), index, value.inner()).to_result(self) }
     }
 
     /// Binds a "uuid" or "timeuuid" to all the values
@@ -659,21 +699,21 @@ impl Statement {
     pub fn bind_uuid_by_name(&mut self, name: &str, value: Uuid) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_uuid_by_name_n(self.0, name_ptr, name.len(), value.inner())
+            cass_statement_bind_uuid_by_name_n(self.inner(), name_ptr, name.len(), value.inner())
                 .to_result(self)
         }
     }
 
     /// Binds an "inet" to a query or bound statement at the specified index.
     pub fn bind_inet(&mut self, index: usize, value: Inet) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_inet(self.0, index, value.inner()).to_result(self) }
+        unsafe { cass_statement_bind_inet(self.inner(), index, value.inner()).to_result(self) }
     }
 
     /// Binds an "inet" to all the values with the specified name.
     pub fn bind_inet_by_name(&mut self, name: &str, value: Inet) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_inet_by_name_n(self.0, name_ptr, name.len(), value.inner())
+            cass_statement_bind_inet_by_name_n(self.inner(), name_ptr, name.len(), value.inner())
                 .to_result(self)
         }
     }
@@ -686,7 +726,7 @@ impl Statement {
     //            unsafe {
     //                CassError::build(
     //                    cass_statement_bind_decimal(
-    //                        self.0,
+    //                        self.inner(),
     //                        index,
     //                        value
     //                    )
@@ -706,7 +746,7 @@ impl Statement {
     //            let name = CString::new(name).unwrap();
     //            CassError::build(
     //            cass_statement_bind_decimal_by_name(
-    //                self.0,
+    //                self.inner(),
     //                name.as_ptr(),
     //                value
     //            )
@@ -716,7 +756,7 @@ impl Statement {
 
     /// Bind a "map" to a query or bound statement at the specified index.
     pub fn bind_map(&mut self, index: usize, map: Map) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_collection(self.0, index, map.inner()).to_result(self) }
+        unsafe { cass_statement_bind_collection(self.inner(), index, map.inner()).to_result(self) }
     }
 
     /// Bind a "map" to all the values with the
@@ -727,13 +767,20 @@ impl Statement {
     pub fn bind_map_by_name(&mut self, name: &str, map: Map) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_collection_by_name_n(self.0, name_ptr, name.len(), map.inner())
-                .to_result(self)
+            cass_statement_bind_collection_by_name_n(
+                self.inner(),
+                name_ptr,
+                name.len(),
+                map.inner(),
+            )
+            .to_result(self)
         }
     }
     /// Bind a "set" to a query or bound statement at the specified index.
     pub fn bind_set(&mut self, index: usize, collection: Set) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_collection(self.0, index, collection.inner()).to_result(self) }
+        unsafe {
+            cass_statement_bind_collection(self.inner(), index, collection.inner()).to_result(self)
+        }
     }
 
     /// Bind a "set" to all the values with the
@@ -745,7 +792,7 @@ impl Statement {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_collection_by_name_n(
-                self.0,
+                self.inner(),
                 name_ptr,
                 name.len(),
                 collection.inner(),
@@ -756,7 +803,9 @@ impl Statement {
 
     /// Bind a "list" to a query or bound statement at the specified index.
     pub fn bind_list(&mut self, index: usize, collection: List) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_collection(self.0, index, collection.inner()).to_result(self) }
+        unsafe {
+            cass_statement_bind_collection(self.inner(), index, collection.inner()).to_result(self)
+        }
     }
 
     /// Bind a "list" to all the values with the
@@ -768,7 +817,7 @@ impl Statement {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_collection_by_name_n(
-                self.0,
+                self.inner(),
                 name_ptr,
                 name.len(),
                 collection.inner(),
@@ -779,7 +828,7 @@ impl Statement {
 
     /// Bind a "tuple" to a query or bound statement at the specified index.
     pub fn bind_tuple(&mut self, index: usize, value: Tuple) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_tuple(self.0, index, value.inner()).to_result(self) }
+        unsafe { cass_statement_bind_tuple(self.inner(), index, value.inner()).to_result(self) }
     }
 
     /// Bind a "tuple" to all the values with the specified name.
@@ -789,7 +838,7 @@ impl Statement {
     pub fn bind_tuple_by_name(&mut self, name: &str, value: Tuple) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_tuple_by_name_n(self.0, name_ptr, name.len(), value.inner())
+            cass_statement_bind_tuple_by_name_n(self.inner(), name_ptr, name.len(), value.inner())
                 .to_result(self)
         }
     }
@@ -797,7 +846,7 @@ impl Statement {
     /// Bind a user defined type to a query or bound statement at the
     /// specified index.
     pub fn bind_user_type(&mut self, index: usize, value: &UserType) -> Result<&mut Self> {
-        unsafe { cass_statement_bind_user_type(self.0, index, value.inner()).to_result(self) }
+        unsafe { cass_statement_bind_user_type(self.inner(), index, value.inner()).to_result(self) }
     }
 
     /// Bind a user defined type to a query or bound statement with the
@@ -805,8 +854,13 @@ impl Statement {
     pub fn bind_user_type_by_name(&mut self, name: &str, value: &UserType) -> Result<&mut Self> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            cass_statement_bind_user_type_by_name_n(self.0, name_ptr, name.len(), value.inner())
-                .to_result(self)
+            cass_statement_bind_user_type_by_name_n(
+                self.inner(),
+                name_ptr,
+                name.len(),
+                value.inner(),
+            )
+            .to_result(self)
         }
     }
 }

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -15,6 +15,7 @@ use crate::cassandra::uuid::Uuid;
 use crate::{CassFuture, Session};
 
 use crate::cassandra_sys::cass_false;
+use crate::cassandra_sys::cass_session_execute;
 use crate::cassandra_sys::cass_statement_add_key_index;
 use crate::cassandra_sys::cass_statement_bind_bool;
 use crate::cassandra_sys::cass_statement_bind_bool_by_name_n;
@@ -66,7 +67,6 @@ use crate::cassandra_sys::cass_true;
 use crate::cassandra_sys::CassStatement as _Statement;
 use crate::cassandra_sys::CASS_UINT64_MAX;
 
-use cassandra_cpp_sys::cass_session_execute;
 use std::os::raw::c_char;
 use time::Duration;
 

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -347,8 +347,10 @@ impl Statement {
     /// Executes the statement.
     pub async fn execute(self) -> Result<CassResult> {
         let (statement, session) = (self.0, self.1);
-        let execute = unsafe { cass_session_execute(session.inner(), statement.inner()) };
-        let fut = <CassFuture<CassResult>>::build(session, execute);
+        let fut = {
+            let execute = unsafe { cass_session_execute(session.inner(), statement.inner()) };
+            <CassFuture<CassResult>>::build(session, execute)
+        };
         fut.await
     }
 

--- a/src/cassandra/time.rs
+++ b/src/cassandra/time.rs
@@ -1,4 +1,4 @@
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 
 use crate::cassandra_sys::cass_time_from_epoch;
 use crate::cassandra_sys::cass_timestamp_gen_free;
@@ -16,10 +16,13 @@ pub struct TimestampGen(*mut _TimestampGen);
 unsafe impl Send for TimestampGen {}
 unsafe impl Sync for TimestampGen {}
 
-impl Protected<*mut _TimestampGen> for TimestampGen {
+impl ProtectedInner<*mut _TimestampGen> for TimestampGen {
     fn inner(&self) -> *mut _TimestampGen {
         self.0
     }
+}
+
+impl Protected<*mut _TimestampGen> for TimestampGen {
     fn build(inner: *mut _TimestampGen) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/tuple.rs
+++ b/src/cassandra/tuple.rs
@@ -4,7 +4,7 @@ use crate::cassandra::data_type::DataType;
 use crate::cassandra::error::*;
 use crate::cassandra::inet::Inet;
 use crate::cassandra::user_type::UserType;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::uuid::Uuid;
 
 use crate::cassandra_sys::cass_false;
@@ -43,10 +43,13 @@ pub struct Tuple(*mut _Tuple);
 // from multiple threads: https://datastax.github.io/cpp-driver/topics/#thread-safety
 unsafe impl Send for Tuple {}
 
-impl Protected<*mut _Tuple> for Tuple {
+impl ProtectedInner<*mut _Tuple> for Tuple {
     fn inner(&self) -> *mut _Tuple {
         self.0
     }
+}
+
+impl Protected<*mut _Tuple> for Tuple {
     fn build(inner: *mut _Tuple) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")

--- a/src/cassandra/util.rs
+++ b/src/cassandra/util.rs
@@ -1,11 +1,21 @@
 //! Assorted helper functions used throughout the code.
 
+use crate::Session;
+
+pub(crate) trait ProtectedInner<T> {
+    fn inner(&self) -> T;
+}
+
 /// Interconvert between external and internal representation.
 /// We can freely do this within this crate, but must not allow
 /// our clients to do this.
-pub(crate) trait Protected<T> {
+pub(crate) trait Protected<T>: ProtectedInner<T> {
     fn build(inner: T) -> Self;
-    fn inner(&self) -> T;
+}
+
+pub(crate) trait ProtectedWithSession<T>: ProtectedInner<T> {
+    fn build(inner: T, session: Session) -> Self;
+    fn inner_session(&self) -> &Session;
 }
 
 /// Enhance a nullary enum as follows:
@@ -69,16 +79,19 @@ macro_rules! enhance_nullary_enum {
             }
         }
 
+        impl $crate::cassandra::util::ProtectedInner<$that_name> for $this_name {
+            fn inner(&self) -> $that_name {
+                match *self {
+                    $( $this_name::$this => $that_name::$that ),*
+                }
+            }
+        }
+
         impl $crate::cassandra::util::Protected<$that_name> for $this_name {
             fn build(inner: $that_name) -> Self {
                 match inner {
                     $( $that_name::$that => $this_name::$this, )*
                     $($( $that_name::$not_that => panic!(stringify!(Unexpected variant $that_name::$not_that)), )*)*
-                }
-            }
-            fn inner(&self) -> $that_name {
-                match *self {
-                    $( $this_name::$this => $that_name::$that ),*
                 }
             }
         }

--- a/src/cassandra/util.rs
+++ b/src/cassandra/util.rs
@@ -15,7 +15,7 @@ pub(crate) trait Protected<T>: ProtectedInner<T> {
 
 pub(crate) trait ProtectedWithSession<T>: ProtectedInner<T> {
     fn build(inner: T, session: Session) -> Self;
-    fn inner_session(&self) -> &Session;
+    fn session(&self) -> &Session;
 }
 
 /// Enhance a nullary enum as follows:

--- a/src/cassandra/uuid.rs
+++ b/src/cassandra/uuid.rs
@@ -1,5 +1,5 @@
 use crate::cassandra::error::*;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 
 use crate::cassandra_sys::cass_uuid_from_string_n;
 use crate::cassandra_sys::cass_uuid_gen_free;
@@ -31,10 +31,13 @@ const CASS_UUID_STRING_LENGTH: usize = 37;
 /// Version 1 (time-based) or version 4 (random) UUID.
 pub struct Uuid(_Uuid);
 
-impl Protected<_Uuid> for Uuid {
+impl ProtectedInner<_Uuid> for Uuid {
     fn inner(&self) -> _Uuid {
         self.0
     }
+}
+
+impl Protected<_Uuid> for Uuid {
     fn build(inner: _Uuid) -> Self {
         Uuid(inner)
     }

--- a/src/cassandra/value.rs
+++ b/src/cassandra/value.rs
@@ -4,7 +4,7 @@ use crate::cassandra::inet::Inet;
 use crate::cassandra::iterator::MapIterator;
 use crate::cassandra::iterator::SetIterator;
 use crate::cassandra::iterator::UserTypeIterator;
-use crate::cassandra::util::Protected;
+use crate::cassandra::util::{Protected, ProtectedInner};
 use crate::cassandra::uuid::Uuid;
 
 use crate::cassandra_sys::cass_collection_append_decimal;
@@ -146,10 +146,13 @@ pub struct Value(*const _CassValue);
 unsafe impl Send for Value {}
 unsafe impl Sync for Value {}
 
-impl Protected<*const _CassValue> for Value {
+impl ProtectedInner<*const _CassValue> for Value {
     fn inner(&self) -> *const _CassValue {
         self.0
     }
+}
+
+impl Protected<*const _CassValue> for Value {
     fn build(inner: *const _CassValue) -> Self {
         if inner.is_null() {
             panic!("Unexpected null pointer")


### PR DESCRIPTION
Internally, we've (discord) wrapped `cassandra-rs` to basically implicitly associate a given Statement, PreparedStatement & Batch with a given Session.

This PR tries to improve upon that, by building that betterment directly into the library. This is most definitely a breaking change, but I think for the better. Given the ubiquity of async rust, I've also dropped support for the `.wait()` function on `CassFuture`, and some functions which used to return a CassFuture, now are just simple `async fn`'s. If you are operating in a synchronous space, you can use something like https://docs.rs/futures/0.3.8/futures/executor/fn.block_on.html - which will provide the machinery required to execute the now async-only code.

Essentially, `Session` now implements `Clone`. The inner pointer to the cassandra session has been moved into a `SessionInner`, which is now wrapped in an `Arc` inside of `Session`.

From there, we can now `Clone` the given `Session` to the relevant `Statement`, `PreparedStatement`, and `Batch` (associated session resource).  This provides a more safe API, as it makes it now impossible to use the wrong associated session resource with an incorrect session. New code, now looks like:

```rust
use cassandra_cpp::*;

async fn create_session() -> Result<Session> {
    let contact_points = "127.0.0.1";
    let mut cluster = Cluster::default();
    cluster.set_contact_points(contact_points)?;
    cluster.set_load_balance_round_robin();

    cluster.connect().await
}

async fn execute_statement() -> Result<()> {
    let session = create_session().await?;
    let result = session
        .statement("SELECT keyspace_name FROM system_schema.keyspaces;")
        .execute()
        .await?;

    for row in result.iter() {
        let col: String = row.get_by_name("keyspace_name")?;
        print!("ks = {}", col);
    }

    Ok(())
}

async fn execute_prepared_statement() -> Result<()> {
    let session = create_session().await?;
    let prepared_statement = session
        .prepare("SELECT value FROM kv_table WHERE key = ?")
        .await?;

    let mut statement = prepared_statement.bind();
    statement.bind_string(0, "key")?;

    let result = statement.execute().await?;
    for row in result.iter() {
        let col: String = row.get_by_name("value")?;
        print!("value = {}", col);
    }

    Ok(())
}


async fn execute_batch_statement() -> Result<()> {
    let session = create_session().await?;
    let mut batch = session.batch(BatchType::LOGGED);
    // note: binding of statement omitted in this example.
    batch.add_statement(session.statement("INSERT INTO kv_table (key, value) VALUES (?, ?)"))?;
    batch.add_statement(session.statement("INSERT INTO kv_table (key, value) VALUES (?, ?)"))?;
    batch.add_statement(session.statement("INSERT INTO kv_table (key, value) VALUES (?, ?)"))?;
    let _result = batch.execute().await?;

    Ok(())
}
```

There are some pitfalls however, which probably merit additional discussion. `execute()` now consumes the given associated session resource, and thus, if you want to execute the same statement multiple times it must be recreated. Practically, I don't think this is an issue, most code, reasonably, executes a statement once, and if it needs to execute it multiple times, it's because it needs different arguments bound to it. 

I've yet to update any tests/examples/docs, those will come as we gain consensus on whether or not this is an acceptable approach. 

## Potential todo list:
 - [x] Make `CassFuture` private to the crate. All public functions that once returned a `CassFuture` will now just be an `async fn`. 
 - [x] Get rid of `Session::new`, `Session::connect` and `Session::connect_keyspace`, and move those all to `Cluster`. 
 - [x] `Batch::add_statement` should consume statement ownership + check if the session it's bound to matches, now that we have that info. 
 - [X] What to do about `Session::close` now that it's an Arc? 
    - ~~One idea, is that we could use `Arc::try_unwrap` to only allow `Close` to succeed once all associated resources are destroyed.~~
    - ~~The other idea is to leave it as is, lingering associated resources will just start to error once the session is closed.~~
    - Removing for now.
 - [x] Get rid of `stmt!` macro. 

## Definite todo list:
  - [ ] update tests
  - [ ] update docs
  - [x] update examples
  - [ ] update changelog
  - [ ] migration guide.