### PR TITLE
chore: fix all warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ cassandra-cpp-sys = "0.12"
 decimal = "2"
 time = "0.2"
 uuid = "0.8"
-error-chain = "0.12.1"
+error-chain = "0.12"
 parking_lot = "0.11"
 
 [dev-dependencies]

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -337,10 +337,9 @@ impl Cluster {
     ///
     ///
     /// Default: 5000ms
-    #[allow(cast_possible_truncation, cast_sign_loss)]
     pub fn set_connect_timeout(&mut self, timeout: Duration) -> &Self {
         unsafe {
-            cass_cluster_set_connect_timeout(self.0, timeout.num_milliseconds() as u32);
+            cass_cluster_set_connect_timeout(self.0, timeout.whole_milliseconds() as u32);
         }
         self
     }
@@ -349,10 +348,9 @@ impl Cluster {
     ///
     ///
     /// Default: 12000ms
-    #[allow(cast_possible_truncation, cast_sign_loss)]
     pub fn set_request_timeout(&mut self, timeout: Duration) -> &Self {
         unsafe {
-            cass_cluster_set_request_timeout(self.0, timeout.num_milliseconds() as u32);
+            cass_cluster_set_request_timeout(self.0, timeout.whole_milliseconds() as u32);
         }
         self
     }
@@ -493,7 +491,6 @@ impl Cluster {
     ///  <li>update_rate_ms: 100 milliseconds</li>
     ///  <li>min_measured: 50</li>
     /// </ul>
-    #[allow(cast_sign_loss)]
     pub fn set_latency_aware_routing_settings(
         &mut self,
         exclusion_threshold: f64,
@@ -506,9 +503,9 @@ impl Cluster {
             cass_cluster_set_latency_aware_routing_settings(
                 self.0,
                 exclusion_threshold,
-                scale.num_milliseconds() as u64,
-                retry_period.num_milliseconds() as u64,
-                update_rate.num_milliseconds() as u64,
+                scale.whole_milliseconds() as u64,
+                retry_period.whole_milliseconds() as u64,
+                update_rate.whole_milliseconds() as u64,
                 min_measured,
             );
         }
@@ -548,13 +545,12 @@ impl Cluster {
     ///
     ///
     /// Default: false (disabled).
-    #[allow(cast_possible_truncation, cast_sign_loss)]
     pub fn set_tcp_keepalive(&mut self, enable: bool, delay: Duration) -> &Self {
         unsafe {
             cass_cluster_set_tcp_keepalive(
                 self.0,
                 if enable { cass_true } else { cass_false },
-                delay.num_seconds() as u32,
+                delay.whole_seconds() as u32,
             );
         }
         self
@@ -579,10 +575,9 @@ impl Cluster {
     ///
     ///
     /// Default: 30 seconds
-    #[allow(cast_possible_truncation, cast_sign_loss)]
     pub fn set_connection_heartbeat_interval(&mut self, hearbeat: Duration) -> &mut Self {
         unsafe {
-            cass_cluster_set_connection_heartbeat_interval(self.0, hearbeat.num_seconds() as u32);
+            cass_cluster_set_connection_heartbeat_interval(self.0, hearbeat.whole_seconds() as u32);
             self
         }
     }
@@ -592,10 +587,9 @@ impl Cluster {
     ///
     ///
     /// Default: 60 seconds
-    #[allow(cast_possible_truncation, cast_sign_loss)]
     pub fn set_connection_idle_timeout(&mut self, timeout: Duration) -> &mut Self {
         unsafe {
-            cass_cluster_set_connection_idle_timeout(self.0, timeout.num_seconds() as u32);
+            cass_cluster_set_connection_idle_timeout(self.0, timeout.whole_seconds() as u32);
             self
         }
     }

--- a/src/cassandra/iterator.rs
+++ b/src/cassandra/iterator.rs
@@ -195,7 +195,6 @@ unsafe impl Send for FieldIterator {}
 
 impl Iterator for FieldIterator {
     type Item = Field;
-    #[allow(cast_possible_truncation)]
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
         unsafe {
             match cass_iterator_next(self.0) {

--- a/src/cassandra/prepared.rs
+++ b/src/cassandra/prepared.rs
@@ -48,7 +48,6 @@ impl PreparedStatement {
     }
 
     /// Gets the name of a parameter at the specified index.
-    #[allow(cast_possible_truncation)]
     pub fn parameter_name(&self, index: usize) -> Result<&str> {
         unsafe {
             let mut name = mem::zeroed();

--- a/src/cassandra/schema/column_meta.rs
+++ b/src/cassandra/schema/column_meta.rs
@@ -39,7 +39,6 @@ impl ColumnMeta {
     }
 
     /// Gets the name of the column.
-    #[allow(cast_possible_truncation)]
     pub fn name(&self) -> String {
         unsafe {
             let mut name = mem::zeroed();

--- a/src/cassandra/schema/function_meta.rs
+++ b/src/cassandra/schema/function_meta.rs
@@ -45,7 +45,6 @@ impl FunctionMeta {
     }
 
     /// Gets the name of the function.
-    #[allow(cast_possible_truncation)]
     pub fn get_name(&self) -> String {
         unsafe {
             let mut name = mem::zeroed();
@@ -63,7 +62,6 @@ impl FunctionMeta {
     /// Gets the full name of the function. The full name includes the
     /// function's name and the function's signature:
     /// "name(type1 type2.. typeN)".
-    #[allow(cast_possible_truncation)]
     pub fn full_name(&self) -> String {
         unsafe {
             let mut name = mem::zeroed();
@@ -79,7 +77,6 @@ impl FunctionMeta {
     }
 
     /// Gets the body of the function.
-    #[allow(cast_possible_truncation)]
     pub fn body(&self) -> String {
         unsafe {
             let mut name = mem::zeroed();
@@ -95,7 +92,6 @@ impl FunctionMeta {
     }
 
     /// Gets the language of the function.
-    #[allow(cast_possible_truncation)]
     pub fn language(&self) -> String {
         unsafe {
             let mut name = mem::zeroed();

--- a/src/cassandra/schema/table_meta.rs
+++ b/src/cassandra/schema/table_meta.rs
@@ -60,7 +60,6 @@ impl TableMeta {
     }
 
     /// Gets the name of the table.
-    #[allow(cast_possible_truncation)]
     pub fn get_name(&self) -> String {
         unsafe {
             let mut name = mem::zeroed();

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -424,7 +424,7 @@ impl Statement {
         unsafe {
             let timeout_millis = match timeout {
                 None => CASS_UINT64_MAX as u64,
-                Some(time) => time.num_milliseconds() as u64,
+                Some(time) => time.whole_milliseconds() as u64,
             };
             cass_statement_set_request_timeout(self.0, timeout_millis);
         }

--- a/src/cassandra/time.rs
+++ b/src/cassandra/time.rs
@@ -40,7 +40,7 @@ impl TimestampGen {
     /// Converts a unix timestamp (in seconds) to the Cassandra "time" type. The "time" type
     /// represents the number of nanoseconds since midnight (range 0 to 86399999999999).
     pub fn time_from_epoch(epoch_seconds: Duration) -> Time {
-        unsafe { Time(cass_time_from_epoch(epoch_seconds.num_seconds())) }
+        unsafe { Time(cass_time_from_epoch(epoch_seconds.whole_seconds())) }
     }
 
     /// Creates a new monotonically increasing timestamp generator. This generates

--- a/src/cassandra/value.rs
+++ b/src/cassandra/value.rs
@@ -302,7 +302,6 @@ impl Display for Value {
 
 impl Value {
     /// Get the raw bytes of this Cassandra value.
-    #[allow(cast_possible_truncation)]
     pub fn get_bytes(&self) -> Result<&[u8]> {
         unsafe {
             let mut output = mem::zeroed();


### PR DESCRIPTION
This PR removes a bunch of warnings, notably:

```
     19 warning: unknown lint: `cast_possible_truncation`
     12 warning: use of deprecated associated function `time::Duration::num_milliseconds`: Use the `whole_milliseconds` function. The value is clamped between `i64::min_value()` and `i64::max_value()`.
      8 warning: use of deprecated associated function `time::Duration::num_seconds`: Use the `whole_seconds` function
      4 warning: use of deprecated associated function `std::error::Error::description`: use the Display impl or to_string()
      3 warning: unknown lint: `cast_sign_loss`
```