### PR TITLE
Batch execution no longer consumes the batch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,11 +26,6 @@ before_install:
   - sudo docker pull cassandra
   - sudo docker run -d --net=host --name=cassandra cassandra
 
-before_script:
-- |
-  pip install 'travis-cargo<0.2' --user &&
-  export PATH=$HOME/.local/bin:/usr/local/bin:$PATH
-
 # Enforce that all new commits are signed off according to the DCO,
 # per CONTRIBUTING.md. Prior commits are either pre-fork, are signed off,
 # or were made by Keith Wansbrough, who hereby certifies the DCO with regard
@@ -47,5 +42,3 @@ script:
   cargo build --all &&
   cargo test -- --test-threads 1
 
-after_success:
-- travis-cargo coveralls --no-sudo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ version number is tracked in the file `VERSION`.
 ## [Unreleased]
 ### Added
 ### Changed
+- Changed `Session::execute_batch` and `Session::execute_batch_with_payloads` to take only 
+  a reference to `Batch` rather than consuming it. This is a breaking change; to update
+  your code, simply change `batch` to `&batch` in your argument list.
+  
 ### Fixed
 
 ## [0.16.0] - 2021-03-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,16 @@ version number is tracked in the file `VERSION`.
 ### Added
 ### Changed
 - Changed `Session::execute_batch` and `Session::execute_batch_with_payloads` to take only 
-  a reference to `Batch` rather than consuming it. This is a breaking change; to update
-  your code, simply change `batch` to `&batch` in your argument list.
+  a reference to `Batch` rather than consuming it.
+
+  This is a breaking change; to update your code, simply change `batch` to `&batch`
+  in your argument list. If this causes an error `future cannot be sent between threads safely`
+  because `&Batch` is `used across an await`, you need to introduce a `let` before the `await`
+  as follows:
+  ```
+  let fut = session.execute_batch(&batch);
+  let result = fut.await?
+  ```
   
 ### Fixed
 

--- a/src/cassandra/session.rs
+++ b/src/cassandra/session.rs
@@ -126,7 +126,7 @@ impl Session {
     //    }
 
     /// Execute a batch statement.
-    pub fn execute_batch(&self, batch: Batch) -> CassFuture<CassResult> {
+    pub fn execute_batch(&self, batch: &Batch) -> CassFuture<CassResult> {
         <CassFuture<CassResult>>::build(unsafe {
             cass_session_execute_batch(self.0, batch.inner())
         })
@@ -135,7 +135,7 @@ impl Session {
     /// Execute a batch statement and get any custom payloads from the response.
     pub fn execute_batch_with_payloads(
         &self,
-        batch: Batch,
+        batch: &Batch,
     ) -> CassFuture<(CassResult, CustomPayloadResponse)> {
         <CassFuture<(CassResult, CustomPayloadResponse)>>::build(unsafe {
             cass_session_execute_batch(self.0, batch.inner())

--- a/tests/batch.rs
+++ b/tests/batch.rs
@@ -26,7 +26,7 @@ fn insert_into_batch_with_prepared(
             Err(err) => panic!("{:?}", err),
         }
     }
-    session.execute_batch(batch).wait()?;
+    session.execute_batch(&batch).wait()?;
     Ok(prepared)
 }
 

--- a/tests/logging.rs
+++ b/tests/logging.rs
@@ -50,6 +50,7 @@ fn test_logging() {
     let log_output: String = drain.0.lock().unwrap().clone();
     assert!(
         log_output.contains("Unable to resolve address for absolute-gibberish.invalid"),
+        "{}",
         log_output
     );
 }

--- a/tests/paging.rs
+++ b/tests/paging.rs
@@ -52,7 +52,7 @@ fn select_from_paging(session: &Session) -> Result<Vec<(String, String)>> {
                     println!("key: '{:?}' value: '{:?}'", &key_str, &value);
                     res.push((key_str, value));
                 }
-                Err(err) => panic!(err),
+                Err(err) => panic!("{}", err),
             }
         }
         has_more_pages = result.has_more_pages();


### PR DESCRIPTION
`Session::execute_batch` and `Session::execute_batch_with_payloads` now take `&Batch` rather than `Batch`.

This was apparently an oversight in the original code; the parallel `execute` takes `&Statement` already.

This is a breaking change, but it's a straightforward fix: just add `&` to your argument list.

While we're here, fix a couple of warnings in test code related to printing panics, and remove travis-cargo (which was intermittently broken, and only used for coverage which we don't look at).

Fixes #118 