### PR TITLE
remove rustc-serialize from dependency tree

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push]
+on: [push,pull_request]
 
 jobs:
   build-and-test:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ version number is tracked in the file `VERSION`.
 ### Changed
 - Move GitHub build to GitHub Actions (was previously Travis).
 ### Fixed
+- Removed unused `decimal` dependency.
 
 ## [0.17.0] - 2021-05-17
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ travis-ci = { repository = "Metaswitch/cassandra-rs" }
 clippy = {version = "0.0", optional = true}
 slog = "2"
 cassandra-cpp-sys = "0.12"
-decimal = "2"
 uuid = "0.8"
 error-chain = "0.12"
 parking_lot = "0.11"


### PR DESCRIPTION
decimal by default pulls in various extra dependencies including the ancient rustc-serialize.

I can see that the project would like to reintroduce decimal support https://github.com/Metaswitch/cassandra-rs/issues/122 so I didnt outright remove this unused dep.
But maybe you would prefer me to just remove the dep so that decimal support can start from scratch and be free to choose a more up to date decimal crate?
