### PR TITLE
Record DCO certification of remaining commit

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
           # 00d3207: Keith Wansbrough hereby certifies the DCO with regard to this commit.
           # 1206d15: Brandon Dail <brandon@dail.family> has certified in https://github.com/Metaswitch/cassandra-rs/pull/117#issuecomment-971611331
           # 865a762: Bot-authored commit, no DCO required.
-          # 741e699: TODO: Jake <me@jh.gg> to certify
+          # 741e699: Jake <me@jh.gg> has certified in https://github.com/Metaswitch/cassandra-rs/pull/93#issuecomment-972289201
           grep -v "00d32073bdc21d992ee645a536e34728ca2a0086\|1206d1506fb7a1df637abe2dac102cfe39e37fb5\|865a76274eab12caddae68f399c571834d213056\|741e6991393f4dcf68f7ab896b21948db3b19d5d" tmp-unsigned-dco > tmp-unsigned-dco-2 || /bin/true
           if [ -s tmp-unsigned-dco-2 ] ; then
             echo '**One or more commits are not signed off! Unsigned commits:'


### PR DESCRIPTION
Record the last missing DCO certification in the build script.