### PR TITLE
Fix UB in Inet::to_string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ version number is tracked in the file `VERSION`.
 ### Changed
 ### Added
 ### Fixed
+- Fixed UB in `Inet::to_string`
 
 ## [0.17.1] - 2022-01-24
 ### Changed

--- a/src/cassandra/inet.rs
+++ b/src/cassandra/inet.rs
@@ -98,9 +98,11 @@ impl FromStr for Inet {
 impl ToString for Inet {
     fn to_string(&self) -> String {
         unsafe {
-            let mut inet_str = mem::zeroed();
-            cass_inet_string(self.0, &mut inet_str);
-            CStr::from_ptr(&inet_str).to_string_lossy().into_owned()
+            let mut inet_str = [0i8; cassandra_cpp_sys::CASS_INET_STRING_LENGTH as usize];
+            cass_inet_string(self.0, inet_str.as_mut_ptr());
+            CStr::from_ptr(inet_str.as_ptr())
+                .to_string_lossy()
+                .into_owned()
         }
     }
 }
@@ -133,4 +135,11 @@ fn ipv6_conversion() {
     let inet = Inet::cass_inet_init_v6(&ipv6_in);
     let ip_out = IpAddr::from(&inet);
     assert_eq!(IpAddr::V6(ipv6_in), ip_out);
+}
+
+#[test]
+fn ipv4_to_string() {
+    let ipv4_in = Ipv4Addr::new(127, 0, 0, 1);
+    let inet = Inet::cass_inet_init_v4(&ipv4_in);
+    assert_eq!("127.0.0.1", inet.to_string());
 }


### PR DESCRIPTION
The inet_str ends up being an `i8` due to type inference.
Attempting to store the bytes of a string in an i8 somehow manages to work most of the time but in rust 1.59 this broke in my application.

I fixed the issue by providing an array of the proper length to store the string bytes.

The test I added didnt pick up the issue in rust 1.59 (such is the nature of UB) but the fix does fix the issue in my application.

I would appreciate a patch release asap after this is merged.