### PR TITLE
Release 0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ version number is tracked in the file `VERSION`.
 ### Changed
 ### Added
 ### Fixed
+
+## [0.17.2] - 2022-03-09
+### Fixed
 - Fixed UB in `Inet::to_string`
 
 ## [0.17.1] - 2022-01-24

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,11 +12,7 @@ version = "0.17.2-pre"
 authors = ["Tupshin Harper <tupshin@tupshin.com>", "Keith Wansbrough <Keith.Wansbrough@metaswitch.com>"]
 edition = "2018"
 
-[badges]
-travis-ci = { repository = "Metaswitch/cassandra-rs" }
-
 [dependencies]
-clippy = {version = "0.0", optional = true}
 slog = "2"
 cassandra-cpp-sys = "0.12"
 uuid = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = [ "Cassandra", "binding", "CQL", "client", "database" ]
 categories = [ "api-bindings", "database", "external-ffi-bindings", "asynchronous" ]
 license = "Apache-2.0"
 name = "cassandra-cpp"
-version = "0.17.2-pre"
+version = "0.17.2"
 authors = ["Tupshin Harper <tupshin@tupshin.com>", "Keith Wansbrough <Keith.Wansbrough@metaswitch.com>"]
 edition = "2018"
 


### PR DESCRIPTION
Release 0.17.2, and also tidy up Cargo.toml: remove traces of travis, and remove bizarre and unused dependency on clippy 0.0.