### PR TITLE
Release 1.0.0

### DIFF
--- a/.floki/Dockerfile
+++ b/.floki/Dockerfile
@@ -6,10 +6,10 @@ RUN apt-get -qq update && \
     apt-get -y -qq install wget multiarch-support build-essential libssl-dev && \
     wget -O rustup.sh https://sh.rustup.rs && \
     sh rustup.sh -y && \
-    wget https://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.35.0/libuv1_1.35.0-1_amd64.deb \
-         https://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.35.0/libuv1-dev_1.35.0-1_amd64.deb \
-         https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.3/cassandra-cpp-driver_2.15.3-1_amd64.deb \
-         https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.15.3/cassandra-cpp-driver-dev_2.15.3-1_amd64.deb && \
+    wget https://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.23.0/libuv1_1.23.0-1_amd64.deb \
+         https://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.23.0/libuv1-dev_1.23.0-1_amd64.deb \
+         https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver_2.16.0-1_amd64.deb \
+         https://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver-dev_2.16.0-1_amd64.deb && \
     dpkg -i *.deb && \
     rm -f *.deb && \
     apt-get clean

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,19 @@ All notable changes to this project will be documented in this file.
 This file's format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/). The
 version number is tracked in the file `VERSION`.
-
 ## [Unreleased]
 ### Changed
 ### Added
-- Added new set_cloud_secure_connection_bundle and set_cloud_secure_connection_bundle_no_ssl_lib_init   
+
+### Fixed
+## [1.0.0] - 2022-03-29
+### Added
+- Added new `set_cloud_secure_connection_bundle` and `set_cloud_secure_connection_bundle_no_ssl_lib_init`
   functions using the functions Datastax defined in
   cassandra-cpp-driver version 2.16.0.
-- Added new error codes LIB_NO_TRACING_ID and SSL_CLOSED
+- Added new error codes `LIB_NO_TRACING_ID` and `SSL_CLOSED`
   using the codes Datastax defined in
   cassandra-cpp-driver version 2.16.0.
-### Fixed
 
 ## [0.17.2] - 2022-03-09
 ### Fixed
@@ -238,7 +240,9 @@ First release of https://github.com/Metaswitch/cassandra-rs
 ## [0.8.1] - 2016-12-13
 Last release of https://github.com/tupshin/cassandra-rs
 
-[Unreleased]: https://github.com/Metaswitch/cassandra-rs/compare/0.17.0...HEAD
+[Unreleased]: https://github.com/Metaswitch/cassandra-rs/compare/1.0.0...HEAD
+[1.0.0]: https://github.com/Metaswitch/cassandra-rs/compare/0.17.2...1.0.0
+[0.17.2]: https://github.com/Metaswitch/cassandra-rs/compare/0.17.1...0.17.2
 [0.17.1]: https://github.com/Metaswitch/cassandra-rs/compare/0.17.0...0.17.1
 [0.17.0]: https://github.com/Metaswitch/cassandra-rs/compare/0.16.0...0.17.0
 [0.16.0]: https://github.com/Metaswitch/cassandra-rs/compare/0.15.1...0.16.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = [ "Cassandra", "binding", "CQL", "client", "database" ]
 categories = [ "api-bindings", "database", "external-ffi-bindings", "asynchronous" ]
 license = "Apache-2.0"
 name = "cassandra-cpp"
-version = "0.17.3-pre"
+version = "1.0.0"
 authors = ["Tupshin Harper <tupshin@tupshin.com>", "Keith Wansbrough <Keith.Wansbrough@metaswitch.com>"]
 edition = "2018"
 

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ It is a wrapper around the raw driver binding crate [cassandra-cpp-sys](https://
 
 ### Local environment
 
-For this crate to work, you must first have installed the datastax-cpp driver.
+For this crate to work, you must first have installed a sufficiently-recent version of the datastax-cpp driver (at least 2.16).
 Follow the steps in the
 [cpp driver docs](https://github.com/datastax/cpp-driver/tree/master/topics#installation)
 to do so. Pre-built packages are available for most platforms.


### PR DESCRIPTION
This has been supported for some time; recognize that at last.

Also update floki file to match the GitHub actions file - use the required Cassandra driver version.

Also update CHANGELOG which was out of date.
