### PR TITLE
Add `early_access_min_tls_version` feature flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,13 @@ version number is tracked in the file `VERSION`.
 ## [Unreleased]
 ### Changed
 ### Added
-- Added new set_cloud_secure_connection_bundle and set_cloud_secure_connection_bundle_no_ssl_lib_init   
+- Added new set_cloud_secure_connection_bundle and set_cloud_secure_connection_bundle_no_ssl_lib_init
   functions using the functions Datastax defined in
   cassandra-cpp-driver version 2.16.0.
 - Added new error codes LIB_NO_TRACING_ID and SSL_CLOSED
   using the codes Datastax defined in
   cassandra-cpp-driver version 2.16.0.
+- Added new `min_tls_version` features, which enables a `set_min_protocol_version` method on an Ssl object.
 ### Fixed
 
 ## [0.17.2] - 2022-03-09

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ version number is tracked in the file `VERSION`.
 
 ## [Unreleased]
 ### Added
-- Added new `min_tls_version` features, which enables a `set_min_protocol_version` method on an Ssl object.
+- Added new `min_tls_version` features, which enables a `set_min_protocol_version` method on an `Ssl` object.
 
 ## [1.0.0] - 2022-03-29
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ edition = "2018"
 
 [dependencies]
 slog = "2"
-cassandra-cpp-sys = "1.0.0"
+cassandra-cpp-sys = "1.1.0"
 uuid = "0.8"
 error-chain = "0.12"
 parking_lot = "0.12"
@@ -22,3 +22,7 @@ parking_lot = "0.12"
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros", "test-util"] }
 futures = "0.3.1"
+
+[features]
+default = []
+early_access_min_tls_version = ["cassandra-cpp-sys/early_access_min_tls_version"]

--- a/README.md
+++ b/README.md
@@ -72,6 +72,11 @@ The API changed significantly in version 0.10.
 (Version 0.9 was skipped, for consistency with the `cassandra-cpp-sys` version number.)
 For a summary of the main changes, see [`CHANGELOG`](CHANGELOG.md#0100).
 
+## Feature flags
+
+This crate includes the feature flag `early_access_min_tls_version`, which allows you to build against a version of the DataStax driver including the `cass_ssl_set_min_protocol_version` method, as defined in [this PR](https://github.com/datastax/cpp-driver/pull/525). You must have a version of the driver supporting this installed local to be able to compile (and run) with this feature flag.
+
+When this this feature is available in the mainline driver this flag will be set to do nothing and deprecated, and the functions will be added to the main library. The flag will then be retired in the next breaking change.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ For a summary of the main changes, see [`CHANGELOG`](CHANGELOG.md#0100).
 
 ## Feature flags
 
-This crate includes the feature flag `early_access_min_tls_version`, which allows you to build against a version of the DataStax driver including the `cass_ssl_set_min_protocol_version` method, as defined in [this PR](https://github.com/datastax/cpp-driver/pull/525). You must have a version of the driver supporting this installed local to be able to compile (and run) with this feature flag.
+This crate includes the feature flag `early_access_min_tls_version`, which allows you to build against a version of the DataStax driver including the `cass_ssl_set_min_protocol_version` method, as defined in [this PR](https://github.com/datastax/cpp-driver/pull/525). You must have a version of the driver supporting this installed locally to be able to compile (and run) with this feature flag.
 
 When this this feature is available in the mainline driver this flag will be set to do nothing and deprecated, and the functions will be added to the main library. The flag will then be retired in the next breaking change.
 

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -163,7 +163,8 @@ impl Cluster {
     pub fn set_cloud_secure_connection_bundle(&mut self, path: &str) -> Result<&mut Self> {
         unsafe {
             let path_ptr = path.as_ptr() as *const c_char;
-            let err = cass_cluster_set_cloud_secure_connection_bundle_n(self.0, path_ptr, path.len());
+            let err =
+                cass_cluster_set_cloud_secure_connection_bundle_n(self.0, path_ptr, path.len());
             err.to_result(self)
         }
     }
@@ -172,10 +173,17 @@ impl Cluster {
     /// does not initialize the underlying SSL library implementation. The SSL library still
     /// needs to be initialized, but it's up to the client application to handle
     /// initialization.
-    pub fn set_cloud_secure_connection_bundle_no_ssl_lib_init(&mut self, path: &str) -> Result<&mut Self> {
+    pub fn set_cloud_secure_connection_bundle_no_ssl_lib_init(
+        &mut self,
+        path: &str,
+    ) -> Result<&mut Self> {
         unsafe {
             let path_ptr = path.as_ptr() as *const c_char;
-            let err = cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init_n(self.0, path_ptr, path.len());
+            let err = cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init_n(
+                self.0,
+                path_ptr,
+                path.len(),
+            );
             err.to_result(self)
         }
     }

--- a/src/cassandra/result.rs
+++ b/src/cassandra/result.rs
@@ -149,13 +149,9 @@ impl CassResult {
         unsafe {
             let mut token_ptr = mem::zeroed();
             let mut token_length = mem::zeroed();
-            cass_result_paging_state_token(
-                self.0,
-                &mut token_ptr,
-                &mut token_length,
-            )
-            .to_result(())
-            .map(|_| {
+            cass_result_paging_state_token(self.0, &mut token_ptr, &mut token_length)
+                .to_result(())
+                .map(|_| {
                     Some(
                         slice::from_raw_parts(token_ptr as *const u8, token_length as usize)
                             .to_vec(),

--- a/src/cassandra/schema/table_meta.rs
+++ b/src/cassandra/schema/table_meta.rs
@@ -125,10 +125,7 @@ impl TableMeta {
     pub fn field_by_name(&self, name: &str) -> Option<Value> {
         // fixme replace CassValule with a custom type
         unsafe {
-            let value = cass_table_meta_field_by_name(
-                self.0,
-                name.as_ptr() as *const c_char,
-            );
+            let value = cass_table_meta_field_by_name(self.0, name.as_ptr() as *const c_char);
             if value.is_null() {
                 None
             } else {

--- a/src/cassandra/ssl.rs
+++ b/src/cassandra/ssl.rs
@@ -9,6 +9,8 @@ use crate::cassandra_sys::cass_ssl_set_private_key_n;
 use crate::cassandra_sys::cass_ssl_set_verify_flags;
 use crate::cassandra_sys::CassSsl as _Ssl;
 use crate::cassandra_sys::CassSslVerifyFlags;
+#[cfg(feature = "early_access_min_tls_version")]
+use crate::cassandra_sys::{cass_ssl_set_min_protocol_version, CassSslTlsVersion as SslTlsVersion};
 
 use std::os::raw::c_char;
 
@@ -116,5 +118,14 @@ impl Ssl {
             cass_ssl_set_private_key_n(self.0, key_ptr, key.len(), password_ptr, password.len())
                 .to_result(self)
         }
+    }
+
+    /// Set minimum TLS version. This helps avoid TLS downgrade attacks.
+    #[cfg(feature = "early_access_min_tls_version")]
+    pub fn set_min_protocol_version(
+        &mut self,
+        min_tls_version: SslTlsVersion,
+    ) -> Result<&mut Self> {
+        unsafe { cass_ssl_set_min_protocol_version(self.0, min_tls_version).to_result(self) }
     }
 }

--- a/src/cassandra/ssl.rs
+++ b/src/cassandra/ssl.rs
@@ -5,12 +5,14 @@ use crate::cassandra_sys::cass_ssl_add_trusted_cert_n;
 use crate::cassandra_sys::cass_ssl_free;
 use crate::cassandra_sys::cass_ssl_new;
 use crate::cassandra_sys::cass_ssl_set_cert_n;
+#[cfg(feature = "early_access_min_tls_version")]
+use crate::cassandra_sys::cass_ssl_set_min_protocol_version;
 use crate::cassandra_sys::cass_ssl_set_private_key_n;
 use crate::cassandra_sys::cass_ssl_set_verify_flags;
 use crate::cassandra_sys::CassSsl as _Ssl;
-use crate::cassandra_sys::CassSslVerifyFlags;
 #[cfg(feature = "early_access_min_tls_version")]
-use crate::cassandra_sys::{cass_ssl_set_min_protocol_version, CassSslTlsVersion as SslTlsVersion};
+pub use crate::cassandra_sys::CassSslTlsVersion as SslTlsVersion;
+use crate::cassandra_sys::CassSslVerifyFlags;
 
 use std::os::raw::c_char;
 

--- a/src/cassandra/user_type.rs
+++ b/src/cassandra/user_type.rs
@@ -394,8 +394,13 @@ impl UserType {
         unsafe {
             let name_str = name.into();
             let name_ptr = name_str.as_ptr() as *const c_char;
-            cass_user_type_set_collection_by_name_n(self.0, name_ptr, name_str.len(), value.into().inner())
-                .to_result(self)
+            cass_user_type_set_collection_by_name_n(
+                self.0,
+                name_ptr,
+                name_str.len(),
+                value.into().inner(),
+            )
+            .to_result(self)
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,6 +43,8 @@ pub use crate::cassandra::schema::keyspace_meta::KeyspaceMeta;
 pub use crate::cassandra::schema::schema_meta::SchemaMeta;
 pub use crate::cassandra::schema::table_meta::TableMeta;
 pub use crate::cassandra::session::Session;
+#[cfg(features = "early_access_min_tls_version")]
+pub use crate::cassandra::ssl::SslTlsVersion;
 pub use crate::cassandra::ssl::{Ssl, SslVerifyFlag};
 pub use crate::cassandra::statement::BindRustType;
 pub use crate::cassandra::statement::Statement;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ pub use crate::cassandra::schema::keyspace_meta::KeyspaceMeta;
 pub use crate::cassandra::schema::schema_meta::SchemaMeta;
 pub use crate::cassandra::schema::table_meta::TableMeta;
 pub use crate::cassandra::session::Session;
-#[cfg(features = "early_access_min_tls_version")]
+#[cfg(feature = "early_access_min_tls_version")]
 pub use crate::cassandra::ssl::SslTlsVersion;
 pub use crate::cassandra::ssl::{Ssl, SslVerifyFlag};
 pub use crate::cassandra::statement::BindRustType;

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -1,5 +1,7 @@
 mod help;
 
+#[cfg(feature = "early_access_min_tls_version")]
+use cassandra_cpp::SslTlsVersion;
 use cassandra_cpp::*;
 
 #[test]
@@ -123,4 +125,16 @@ fn test_parsing_printing_batch_type() {
     let _ = "INVALID"
         .parse::<BatchType>()
         .expect_err("Should have failed to parse");
+}
+
+#[cfg(feature = "early_access_min_tls_version")]
+#[test]
+fn test_using_min_tls_version() {
+    let mut ssl = Ssl::default();
+    ssl.set_min_protocol_version(SslTlsVersion::CASS_SSL_VERSION_TLS1)
+        .expect("Failed to set TLS Version");
+    ssl.set_min_protocol_version(SslTlsVersion::CASS_SSL_VERSION_TLS1_1)
+        .expect("Failed to set TLS Version");
+    ssl.set_min_protocol_version(SslTlsVersion::CASS_SSL_VERSION_TLS1_2)
+        .expect("Failed to set TLS Version");
 }


### PR DESCRIPTION
This PR propagates the feature flag from https://github.com/Metaswitch/cassandra-sys-rs/pull/46 . I've added some test for this that don't pass automatically - since they need a custom compiled version of the Datastax driver - but they pass when you build and install the driver library in question.