### PR TITLE
fix ARM unsigned char (#137)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ cassandra-cpp-sys = "1.1.0"
 uuid = "0.8"
 error-chain = "0.12"
 parking_lot = "0.12"
+libc = "0.2"
 
 [dev-dependencies]
 tokio = { version = "1.0", features = ["rt", "rt-multi-thread", "macros", "test-util"] }

--- a/src/cassandra/inet.rs
+++ b/src/cassandra/inet.rs
@@ -99,8 +99,8 @@ impl ToString for Inet {
     fn to_string(&self) -> String {
         unsafe {
             let mut inet_str = [0i8; cassandra_cpp_sys::CASS_INET_STRING_LENGTH as usize];
-            cass_inet_string(self.0, inet_str.as_mut_ptr());
-            CStr::from_ptr(inet_str.as_ptr())
+            cass_inet_string(self.0, inet_str.as_mut_ptr() as *mut libc::c_char );
+            CStr::from_ptr(inet_str.as_ptr()  as *const libc::c_char )
                 .to_string_lossy()
                 .into_owned()
         }


### PR DESCRIPTION
While i8 works fine on some platforms, ARM and some other places rely on
unsigned chars that libc provides

All the credit for the work done here goes to @stefanofranz, on PR #137 (for context, I copied his code, because the older PR was getting stale)