### PR TITLE
The scope of the unsafe block can be appropriately reduced

### DIFF
--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -123,11 +123,11 @@ impl Cluster {
     ///
     ///
     pub fn set_contact_points(&mut self, contact_points: &str) -> Result<&mut Self> {
-        unsafe {
+        
             let cp_ptr = contact_points.as_ptr() as *const c_char;
-            let err = cass_cluster_set_contact_points_n(self.0, cp_ptr, contact_points.len());
+            let err = unsafe { cass_cluster_set_contact_points_n(self.0, cp_ptr, contact_points.len()) };
             err.to_result(self)
-        }
+        
     }
 
     /// Sets the local address to bind when connecting to the cluster,
@@ -135,11 +135,11 @@ impl Cluster {
     ///
     /// Only numeric addresses are supported.
     pub fn set_local_address(&mut self, name: &str) -> Result<&mut Self> {
-        unsafe {
+        
             let name_ptr = name.as_ptr() as *const c_char;
-            let err = cass_cluster_set_local_address_n(self.0, name_ptr, name.len());
+            let err = unsafe { cass_cluster_set_local_address_n(self.0, name_ptr, name.len()) };
             err.to_result(self)
-        }
+        
     }
 
     /// Sets the port
@@ -161,12 +161,12 @@ impl Cluster {
 
     /// Sets the secure connection bundle path for processing DBaaS credentials.
     pub fn set_cloud_secure_connection_bundle(&mut self, path: &str) -> Result<&mut Self> {
-        unsafe {
+        
             let path_ptr = path.as_ptr() as *const c_char;
             let err =
-                cass_cluster_set_cloud_secure_connection_bundle_n(self.0, path_ptr, path.len());
+                unsafe { cass_cluster_set_cloud_secure_connection_bundle_n(self.0, path_ptr, path.len()) };
             err.to_result(self)
-        }
+        
     }
 
     /// Sets the secure connection bundle path for processing DBaaS credentials, but it
@@ -177,35 +177,35 @@ impl Cluster {
         &mut self,
         path: &str,
     ) -> Result<&mut Self> {
-        unsafe {
+        
             let path_ptr = path.as_ptr() as *const c_char;
-            let err = cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init_n(
+            let err = unsafe { cass_cluster_set_cloud_secure_connection_bundle_no_ssl_lib_init_n(
                 self.0,
                 path_ptr,
                 path.len(),
-            );
+            ) };
             err.to_result(self)
-        }
+        
     }
 
     /// Performs a blocking call to connect to Cassandra cluster
     pub fn connect(&mut self) -> Result<Session> {
-        unsafe {
-            let session = Session(cass_session_new());
-            let connect_future = <CassFuture<()>>::build(cass_session_connect(session.0, self.0));
+        
+            let session = Session(unsafe { cass_session_new() });
+            let connect_future = <CassFuture<()>>::build(unsafe { cass_session_connect(session.0, self.0) });
             connect_future.wait()?;
             Ok(session)
-        }
+        
     }
 
     /// Asynchronously connects to the cassandra cluster
     pub async fn connect_async(&mut self) -> Result<Session> {
-        unsafe {
-            let session = Session(cass_session_new());
-            let connect_future = <CassFuture<()>>::build(cass_session_connect(session.0, self.0));
+        
+            let session = Session(unsafe { cass_session_new() });
+            let connect_future = <CassFuture<()>>::build(unsafe { cass_session_connect(session.0, self.0) });
             connect_future.await?;
             Ok(session)
-        }
+        
     }
 
     /// Sets the protocol version. This will automatically downgrade to the lowest
@@ -388,9 +388,9 @@ impl Cluster {
 
     /// Sets credentials for plain text authentication.
     pub fn set_credentials(&mut self, username: &str, password: &str) -> Result<&mut Self> {
+        let username_ptr = username.as_ptr() as *const c_char;
+        let password_ptr = password.as_ptr() as *const c_char;
         unsafe {
-            let username_ptr = username.as_ptr() as *const c_char;
-            let password_ptr = password.as_ptr() as *const c_char;
             cass_cluster_set_credentials_n(
                 self.0,
                 username_ptr,

--- a/src/cassandra/collection.rs
+++ b/src/cassandra/collection.rs
@@ -238,19 +238,19 @@ impl CassCollection for List {
 
     /// Appends an "ascii", "text" or "varchar" to the collection.
     fn append_string(&mut self, value: &str) -> Result<&mut Self> {
-        unsafe {
+        
             let value_ptr = value.as_ptr() as *const c_char;
-            let result = cass_collection_append_string_n(self.inner(), value_ptr, value.len());
+            let result = unsafe { cass_collection_append_string_n(self.inner(), value_ptr, value.len()) };
             result.to_result(self)
-        }
+        
     }
 
     /// Appends a "blob", "varint" or "custom" to the collection.
     fn append_bytes(&mut self, value: Vec<u8>) -> Result<&mut Self> {
-        unsafe {
-            let bytes = cass_collection_append_bytes(self.inner(), value[..].as_ptr(), value.len());
+        
+            let bytes = unsafe { cass_collection_append_bytes(self.inner(), value[..].as_ptr(), value.len()) };
             bytes.to_result(self)
-        }
+        
     }
 
     /// Appends a "uuid" or "timeuuid"  to the collection.
@@ -374,19 +374,19 @@ impl CassCollection for Set {
 
     /// Appends an "ascii", "text" or "varchar" to the collection.
     fn append_string(&mut self, value: &str) -> Result<&mut Self> {
-        unsafe {
+        
             let value_ptr = value.as_ptr() as *const c_char;
-            let result = cass_collection_append_string_n(self.inner(), value_ptr, value.len());
+            let result = unsafe { cass_collection_append_string_n(self.inner(), value_ptr, value.len()) };
             result.to_result(self)
-        }
+        
     }
 
     /// Appends a "blob", "varint" or "custom" to the collection.
     fn append_bytes(&mut self, value: Vec<u8>) -> Result<&mut Self> {
-        unsafe {
-            let bytes = cass_collection_append_bytes(self.inner(), value[..].as_ptr(), value.len());
+        
+            let bytes = unsafe { cass_collection_append_bytes(self.inner(), value[..].as_ptr(), value.len()) };
             bytes.to_result(self)
-        }
+        
     }
 
     /// Appends a "uuid" or "timeuuid"  to the collection.
@@ -506,19 +506,19 @@ impl CassCollection for Map {
 
     /// Appends an "ascii", "text" or "varchar" to the collection.
     fn append_string(&mut self, value: &str) -> Result<&mut Self> {
-        unsafe {
+        
             let value_ptr = value.as_ptr() as *const c_char;
-            let result = cass_collection_append_string_n(self.inner(), value_ptr, value.len());
+            let result = unsafe { cass_collection_append_string_n(self.inner(), value_ptr, value.len()) };
             result.to_result(self)
-        }
+        
     }
 
     /// Appends a "blob", "varint" or "custom" to the collection.
     fn append_bytes(&mut self, value: Vec<u8>) -> Result<&mut Self> {
-        unsafe {
-            let bytes = cass_collection_append_bytes(self.inner(), value[..].as_ptr(), value.len());
+        
+            let bytes = unsafe { cass_collection_append_bytes(self.inner(), value[..].as_ptr(), value.len()) };
             bytes.to_result(self)
-        }
+        
     }
 
     /// Appends a "uuid" or "timeuuid"  to the collection.

--- a/src/cassandra/custom_payload.rs
+++ b/src/cassandra/custom_payload.rs
@@ -40,8 +40,8 @@ impl Default for CustomPayload {
 impl CustomPayload {
     /// Sets an item to the custom payload.
     pub fn set(&self, name: String, value: &[u8]) -> Result<()> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             Ok(cass_custom_payload_set_n(
                 self.0,
                 name_ptr,

--- a/src/cassandra/data_type.rs
+++ b/src/cassandra/data_type.rs
@@ -115,15 +115,15 @@ impl DataType {
     where
         S: Into<String>,
     {
-        unsafe {
+        
             let type_name2 = CString::new(type_name.into())?;
-            let err = cass_data_type_type_name(
+            let err = unsafe { cass_data_type_type_name(
                 data_type.0,
                 &mut type_name2.as_ptr(),
                 &mut (type_name2.as_bytes().len()),
-            );
+            ) };
             err.to_result(())
-        }
+        
     }
 
     /// Sets the type name of a UDT data type.
@@ -133,12 +133,12 @@ impl DataType {
     where
         S: Into<String>,
     {
-        unsafe {
+        
             let type_name_str = type_name.into();
             let type_name_ptr = type_name_str.as_ptr() as *const c_char;
-            cass_data_type_set_type_name_n(data_type.0, type_name_ptr, type_name_str.len())
-                .to_result(())
-        }
+            unsafe { cass_data_type_set_type_name_n(data_type.0, type_name_ptr, type_name_str.len())
+                .to_result(()) }
+        
     }
 
     /// Gets the type name of a UDT data type.
@@ -148,8 +148,8 @@ impl DataType {
     where
         S: Into<String>,
     {
+        let keyspace2 = CString::new(keyspace.into())?;
         unsafe {
-            let keyspace2 = CString::new(keyspace.into())?;
             cass_data_type_keyspace(
                 data_type.0,
                 &mut (keyspace2.as_ptr()),
@@ -166,9 +166,9 @@ impl DataType {
     where
         S: Into<String>,
     {
+        let keyspace_str = keyspace.into();
+        let keyspace_ptr = keyspace_str.as_ptr() as *const c_char;
         unsafe {
-            let keyspace_str = keyspace.into();
-            let keyspace_ptr = keyspace_str.as_ptr() as *const c_char;
             cass_data_type_set_keyspace_n(data_type.0, keyspace_ptr, keyspace_str.len())
                 .to_result(())
         }
@@ -181,8 +181,8 @@ impl DataType {
     where
         S: Into<String>,
     {
+        let class_name2 = CString::new(class_name.into())?;
         unsafe {
-            let class_name2 = CString::new(class_name.into())?;
             cass_data_type_class_name(
                 data_type.0,
                 &mut class_name2.as_ptr(),
@@ -199,9 +199,9 @@ impl DataType {
     where
         S: Into<String>,
     {
+        let class_name_str = class_name.into();
+        let class_name_ptr = class_name_str.as_ptr() as *const c_char;
         unsafe {
-            let class_name_str = class_name.into();
-            let class_name_ptr = class_name_str.as_ptr() as *const c_char;
             cass_data_type_set_class_name_n(self.0, class_name_ptr, class_name_str.len())
                 .to_result(())
         }
@@ -231,9 +231,9 @@ impl DataType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             // TODO: can return NULL
             ConstDataType::build(cass_data_type_sub_data_type_by_name_n(
                 data_type.0,
@@ -250,8 +250,8 @@ impl DataType {
     where
         S: Into<String>,
     {
+        let name2 = CString::new(name.into())?;
         unsafe {
-            let name2 = CString::new(name.into())?;
             cass_data_type_sub_type_name(
                 data_type.0,
                 index,
@@ -276,9 +276,9 @@ impl DataType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_data_type_add_sub_type_by_name_n(self.0, name_ptr, name_str.len(), sub_data_type.0)
                 .to_result(())
         }
@@ -301,9 +301,9 @@ impl DataType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_data_type_add_sub_value_type_by_name_n(
                 self.0,
                 name_ptr,

--- a/src/cassandra/error.rs
+++ b/src/cassandra/error.rs
@@ -82,26 +82,26 @@ pub(crate) trait CassErrorExt {
 
 impl CassErrorExt for CassError_ {
     fn to_result<T>(&self, default: T) -> Result<T> {
-        unsafe {
+        
             match *self {
                 CASS_OK => Ok(default),
                 _ => {
-                    let message = CStr::from_ptr(cass_error_desc(*self))
+                    let message = unsafe {CStr::from_ptr(cass_error_desc(*self))}
                         .to_string_lossy()
                         .into_owned();
                     Err(ErrorKind::CassError(CassErrorCode::build(*self), message).into())
                 }
             }
-        }
+        
     }
 
     fn to_error(&self) -> Error {
-        unsafe {
-            let message = CStr::from_ptr(cass_error_desc(*self))
+        
+            let message = unsafe {CStr::from_ptr(cass_error_desc(*self))}
                 .to_string_lossy()
                 .into_owned();
             ErrorKind::CassError(CassErrorCode::build(*self), message).into()
-        }
+        
     }
 }
 

--- a/src/cassandra/inet.rs
+++ b/src/cassandra/inet.rs
@@ -84,26 +84,26 @@ impl FromStr for Inet {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self> {
-        unsafe {
-            let mut inet = mem::zeroed();
+        
+            let mut inet = unsafe { mem::zeroed() };
 
             let s_ptr = s.as_ptr() as *const c_char;
-            cass_inet_from_string_n(s_ptr, s.len(), &mut inet)
+            unsafe { cass_inet_from_string_n(s_ptr, s.len(), &mut inet)
                 .to_result(())
-                .and_then(|_| Ok(Inet(inet)))
-        }
+                .and_then(|_| Ok(Inet(inet)))}
+        
     }
 }
 
 impl ToString for Inet {
     fn to_string(&self) -> String {
-        unsafe {
+        
             let mut inet_str = [0i8; cassandra_cpp_sys::CASS_INET_STRING_LENGTH as usize];
-            cass_inet_string(self.0, inet_str.as_mut_ptr() as *mut libc::c_char );
-            CStr::from_ptr(inet_str.as_ptr()  as *const libc::c_char )
+            unsafe { cass_inet_string(self.0, inet_str.as_mut_ptr() as *mut libc::c_char ) };
+            unsafe {CStr::from_ptr(inet_str.as_ptr()  as *const libc::c_char )}
                 .to_string_lossy()
                 .into_owned()
-        }
+        
     }
 }
 

--- a/src/cassandra/iterator.rs
+++ b/src/cassandra/iterator.rs
@@ -47,15 +47,15 @@ impl Drop for AggregateIterator {
 impl Iterator for AggregateIterator {
     type Item = AggregateMeta;
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        unsafe {
-            match cass_iterator_next(self.0) {
+        
+            match unsafe {cass_iterator_next(self.0)} {
                 cass_false => None,
                 cass_true => {
-                    let field_value = cass_iterator_get_aggregate_meta(self.0);
+                    let field_value = unsafe {cass_iterator_get_aggregate_meta(self.0) };
                     Some(AggregateMeta::build(field_value))
                 }
             }
-        }
+        
     }
 }
 
@@ -76,12 +76,12 @@ impl Drop for UserTypeIterator {
 impl Iterator for UserTypeIterator {
     type Item = (String, Value);
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        unsafe {
-            match cass_iterator_next(self.0) {
+        
+            match unsafe {cass_iterator_next(self.0)} {
                 cass_false => None,
                 cass_true => Some((self.get_field_name(), self.get_field_value())),
             }
-        }
+        
     }
 }
 

--- a/src/cassandra/log.rs
+++ b/src/cassandra/log.rs
@@ -86,15 +86,15 @@ unsafe extern "C" fn logger_callback(log: *const CassLogMessage, data: *mut raw:
 
 /// Set or unset a logger to receive all Cassandra driver logs.
 pub fn set_logger(logger: Option<slog::Logger>) {
-    unsafe {
+    
         match logger {
             Some(logger) => {
                 // Pass ownership to C. In fact we leak the logger; it never gets freed.
                 // We don't expect this to be called many times, so we're not worried.
                 let data = Box::new(logger);
-                cass_log_set_callback(Some(logger_callback), Box::into_raw(data) as _)
+                unsafe { cass_log_set_callback(Some(logger_callback), Box::into_raw(data) as _)}
             }
-            None => cass_log_set_callback(None, ptr::null_mut()),
+            None => unsafe {cass_log_set_callback(None, ptr::null_mut())},
         }
-    }
+    
 }

--- a/src/cassandra/result.rs
+++ b/src/cassandra/result.rs
@@ -119,12 +119,12 @@ impl CassResult {
 
     /// Gets the first row of the result.
     pub fn first_row(&self) -> Option<Row> {
-        unsafe {
+        
             match self.row_count() {
                 0 => None,
-                _ => Some(Row::build(cass_result_first_row(self.0))),
+                _ => Some(Row::build(unsafe {cass_result_first_row(self.0)})),
             }
-        }
+        
     }
 
     /// Returns true if there are more pages.
@@ -191,12 +191,12 @@ impl<'a> Drop for ResultIterator<'a> {
 impl<'a> Iterator for ResultIterator<'a> {
     type Item = Row<'a>;
     fn next(&mut self) -> Option<<Self as Iterator>::Item> {
-        unsafe {
-            match cass_iterator_next(self.0) {
+        
+            match unsafe {cass_iterator_next(self.0)} {
                 cass_false => None,
                 cass_true => Some(self.get_row()),
             }
-        }
+        
     }
 
     fn size_hint(&self) -> (usize, Option<usize>) {

--- a/src/cassandra/row.rs
+++ b/src/cassandra/row.rs
@@ -314,14 +314,14 @@ impl AsRustType<Vec<u8>> for Row<'_> {
 impl<'a> Row<'a> {
     /// Get a particular column by index
     pub fn get_column(&self, index: usize) -> Result<Value> {
-        unsafe {
-            let col = cass_row_get_column(self.0, index);
+        
+            let col = unsafe {cass_row_get_column(self.0, index)};
             if col.is_null() {
                 Err(CassErrorCode::LIB_INDEX_OUT_OF_BOUNDS.to_error())
             } else {
                 Ok(Value::build(col))
             }
-        }
+        
     }
 
     /// Get a particular column by name
@@ -329,16 +329,16 @@ impl<'a> Row<'a> {
     where
         S: Into<String>,
     {
-        unsafe {
+        
             let name_str = name.into();
             let name_ptr = name_str.as_ptr() as *const c_char;
-            let col = cass_row_get_column_by_name_n(self.0, name_ptr, name_str.len());
+            let col = unsafe {cass_row_get_column_by_name_n(self.0, name_ptr, name_str.len())};
             if col.is_null() {
                 Err(CassErrorCode::LIB_INDEX_OUT_OF_BOUNDS.to_error())
             } else {
                 Ok(Value::build(col))
             }
-        }
+        
     }
 }
 

--- a/src/cassandra/schema/aggregate_meta.rs
+++ b/src/cassandra/schema/aggregate_meta.rs
@@ -102,14 +102,14 @@ impl AggregateMeta {
     ///  Gets a metadata field for the provided name. Metadata fields allow direct
     /// access to the column data found in the underlying "aggregates" metadata table.
     pub fn field_by_name(&self, name: &str) -> Option<Value> {
-        unsafe {
+        
             let name_ptr = name.as_ptr() as *const c_char;
-            let agg = cass_aggregate_meta_field_by_name_n(self.0, name_ptr, name.len());
+            let agg = unsafe {cass_aggregate_meta_field_by_name_n(self.0, name_ptr, name.len())};
             if agg.is_null() {
                 None
             } else {
                 Some(Value::build(agg))
             }
-        }
+        
     }
 }

--- a/src/cassandra/schema/column_meta.rs
+++ b/src/cassandra/schema/column_meta.rs
@@ -62,14 +62,14 @@ impl ColumnMeta {
     /// Gets a metadata field for the provided name. Metadata fields allow direct
     /// access to the column data found in the underlying "columns" metadata table.
     pub fn field_by_name(&self, name: &str) -> Option<Value> {
-        unsafe {
+        
             let name_ptr = name.as_ptr() as *const c_char;
-            let field = cass_column_meta_field_by_name_n(self.0, name_ptr, name.len());
+            let field = unsafe { cass_column_meta_field_by_name_n(self.0, name_ptr, name.len()) };
             if field.is_null() {
                 None
             } else {
                 Some(Value::build(field))
             }
-        }
+        
     }
 }

--- a/src/cassandra/schema/function_meta.rs
+++ b/src/cassandra/schema/function_meta.rs
@@ -130,8 +130,8 @@ impl FunctionMeta {
 
     /// Gets the function's argument and type for the provided name.
     pub fn argument_type_by_name(&self, name: &str) -> ConstDataType {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             // TODO: can return NULL
             ConstDataType::build(cass_function_meta_argument_type_by_name_n(
                 self.0,
@@ -149,8 +149,8 @@ impl FunctionMeta {
     /// Gets a metadata field for the provided name. Metadata fields allow direct
     /// access to the column data found in the underlying "functions" metadata table.
     pub fn field_by_name(&self, name: &str) -> Value {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             // TODO: can return NULL
             Value::build(cass_function_meta_field_by_name_n(
                 self.0,

--- a/src/cassandra/schema/keyspace_meta.rs
+++ b/src/cassandra/schema/keyspace_meta.rs
@@ -60,49 +60,49 @@ impl KeyspaceMeta {
 
     /// Gets the table metadata for the provided table name.
     pub fn table_by_name(&self, name: &str) -> Option<TableMeta> {
-        unsafe {
+        
             let name_ptr = name.as_ptr() as *const c_char;
-            let value = cass_keyspace_meta_table_by_name_n(self.0, name_ptr, name.len());
+            let value = unsafe {cass_keyspace_meta_table_by_name_n(self.0, name_ptr, name.len())};
             if value.is_null() {
                 None
             } else {
                 Some(TableMeta::build(value))
             }
-        }
+        
     }
 
     /// Gets the data type for the provided type name.
     pub fn user_type_by_name(&self, name: &str) -> Option<ConstDataType> {
-        unsafe {
+        
             let name_ptr = name.as_ptr() as *const c_char;
-            let value = cass_keyspace_meta_user_type_by_name_n(self.0, name_ptr, name.len());
+            let value = unsafe {cass_keyspace_meta_user_type_by_name_n(self.0, name_ptr, name.len())};
             if value.is_null() {
                 None
             } else {
                 Some(ConstDataType::build(value))
             }
-        }
+        
     }
 
     /// Gets the function metadata for the provided function name.
     pub fn get_function_by_name(&self, name: &str, arguments: Vec<&str>) -> Option<FunctionMeta> {
-        unsafe {
+        
             let name_ptr = name.as_ptr() as *const c_char;
             let arguments_str = arguments.join(",");
             let arguments_ptr = arguments_str.as_ptr() as *const c_char;
-            let value = cass_keyspace_meta_function_by_name_n(
+            let value = unsafe {cass_keyspace_meta_function_by_name_n(
                 self.0,
                 name_ptr,
                 name.len(),
                 arguments_ptr,
                 arguments_str.len(),
-            );
+            )};
             if value.is_null() {
                 None
             } else {
                 Some(FunctionMeta::build(value))
             }
-        }
+        
     }
 
     /// Gets the aggregate metadata for the provided aggregate name.

--- a/src/cassandra/schema/schema_meta.rs
+++ b/src/cassandra/schema/schema_meta.rs
@@ -42,8 +42,8 @@ impl SchemaMeta {
     /// Gets the keyspace metadata for the provided keyspace name.
     pub fn get_keyspace_by_name(&self, keyspace: &str) -> KeyspaceMeta {
         // TODO: can return NULL
+        let keyspace_ptr = keyspace.as_ptr() as *const c_char;
         unsafe {
-            let keyspace_ptr = keyspace.as_ptr() as *const c_char;
             KeyspaceMeta::build(cass_schema_meta_keyspace_by_name_n(
                 self.0,
                 keyspace_ptr,

--- a/src/cassandra/schema/table_meta.rs
+++ b/src/cassandra/schema/table_meta.rs
@@ -93,14 +93,14 @@ impl TableMeta {
 
     /// Gets the partition key column metadata for the provided index.
     pub fn partition_key(&self, index: usize) -> Option<ColumnMeta> {
-        unsafe {
-            let key = cass_table_meta_partition_key(self.0, index);
+        
+            let key = unsafe {cass_table_meta_partition_key(self.0, index)};
             if key.is_null() {
                 None
             } else {
                 Some(ColumnMeta::build(key))
             }
-        }
+        
     }
 
     /// Gets the number of columns for the table's clustering key
@@ -110,27 +110,27 @@ impl TableMeta {
 
     /// Gets the clustering key column metadata for the provided index.
     pub fn cluster_key(&self, index: usize) -> Option<ColumnMeta> {
-        unsafe {
-            let key = cass_table_meta_clustering_key(self.0, index);
+        
+            let key = unsafe {cass_table_meta_clustering_key(self.0, index)};
             if key.is_null() {
                 None
             } else {
                 Some(ColumnMeta::build(key))
             }
-        }
+        
     }
 
     /// Gets a metadata field for the provided name. Metadata fields allow direct
     /// access to the column data found in the underlying "tables" metadata table.
     pub fn field_by_name(&self, name: &str) -> Option<Value> {
         // fixme replace CassValule with a custom type
-        unsafe {
-            let value = cass_table_meta_field_by_name(self.0, name.as_ptr() as *const c_char);
+        
+            let value = unsafe {cass_table_meta_field_by_name(self.0, name.as_ptr() as *const c_char)};
             if value.is_null() {
                 None
             } else {
                 Some(Value::build(value))
             }
-        }
+        
     }
 }

--- a/src/cassandra/session.rs
+++ b/src/cassandra/session.rs
@@ -109,8 +109,8 @@ impl Session {
 
     /// Create a prepared statement.
     pub fn prepare(&self, query: &str) -> Result<CassFuture<PreparedStatement>> {
+        let query_ptr = query.as_ptr() as *const c_char;
         unsafe {
-            let query_ptr = query.as_ptr() as *const c_char;
             Ok(<CassFuture<PreparedStatement>>::build(
                 cass_session_prepare_n(self.0, query_ptr, query.len()),
             ))

--- a/src/cassandra/ssl.rs
+++ b/src/cassandra/ssl.rs
@@ -80,8 +80,8 @@ impl Ssl {
     /// Adds a trusted certificate. This is used to verify
     /// the peer's certificate.
     pub fn add_trusted_cert(&mut self, cert: &str) -> Result<&mut Self> {
+        let cert_ptr = cert.as_ptr() as *const c_char;
         unsafe {
-            let cert_ptr = cert.as_ptr() as *const c_char;
             cass_ssl_add_trusted_cert_n(self.0, cert_ptr, cert.len()).to_result(self)
         }
     }
@@ -105,8 +105,8 @@ impl Ssl {
     /// the client on the server-side. This should contain the entire
     /// Certificate chain starting with the certificate itself.
     pub fn set_cert(&mut self, cert: &str) -> Result<&mut Self> {
+        let cert_ptr = cert.as_ptr() as *const c_char;
         unsafe {
-            let cert_ptr = cert.as_ptr() as *const c_char;
             cass_ssl_set_cert_n(self.0, cert_ptr, cert.len()).to_result(self)
         }
     }
@@ -114,9 +114,9 @@ impl Ssl {
     /// Set client-side private key. This is used to authenticate
     /// the client on the server-side.
     pub fn set_private_key(&mut self, key: &str, password: &str) -> Result<&mut Self> {
+        let key_ptr = key.as_ptr() as *const c_char;
+        let password_ptr = key.as_ptr() as *const c_char;
         unsafe {
-            let key_ptr = key.as_ptr() as *const c_char;
-            let password_ptr = key.as_ptr() as *const c_char;
             cass_ssl_set_private_key_n(self.0, key_ptr, key.len(), password_ptr, password.len())
                 .to_result(self)
         }

--- a/src/cassandra/statement.rs
+++ b/src/cassandra/statement.rs
@@ -320,8 +320,8 @@ impl BindRustType<Vec<u8>> for Statement {
 impl Statement {
     /// Creates a new query statement.
     pub fn new(query: &str, parameter_count: usize) -> Self {
+        let query_ptr = query.as_ptr() as *const c_char;
         unsafe {
-            let query_ptr = query.as_ptr() as *const c_char;
             Statement(cass_statement_new_n(
                 query_ptr,
                 query.len(),
@@ -359,8 +359,8 @@ impl Statement {
     /// This is not necessary for prepared statements, as the keyspace
     /// is determined in the metadata processed in the prepare phase.
     pub fn set_keyspace(&mut self, keyspace: String) -> Result<&mut Self> {
+        let keyspace_ptr = keyspace.as_ptr() as *const c_char;
         unsafe {
-            let keyspace_ptr = keyspace.as_ptr() as *const c_char;
             cass_statement_set_keyspace_n(self.0, keyspace_ptr, keyspace.len()).to_result(self)
         }
     }
@@ -421,11 +421,11 @@ impl Statement {
     /// Some(Duration::milliseconds(0)) sets no timeout, and None disables it
     /// (to use the cluster-level request timeout).
     pub fn set_statement_request_timeout(&mut self, timeout: Option<Duration>) -> &mut Self {
+        let timeout_millis = match timeout {
+            None => CASS_UINT64_MAX as u64,
+            Some(time) => time.as_millis() as u64,
+        };
         unsafe {
-            let timeout_millis = match timeout {
-                None => CASS_UINT64_MAX as u64,
-                Some(time) => time.as_millis() as u64,
-            };
             cass_statement_set_request_timeout(self.0, timeout_millis);
         }
         self
@@ -451,8 +451,8 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_null_by_name(&mut self, name: &str) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_null_by_name_n(self.0, name_ptr, name.len()).to_result(self)
         }
     }
@@ -464,8 +464,8 @@ impl Statement {
 
     /// Binds a "tinyint" to all the values with the specified name.
     pub fn bind_int8_by_name(&mut self, name: &str, value: i8) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_int8_by_name_n(self.0, name_ptr, name.len(), value).to_result(self)
         }
     }
@@ -477,8 +477,8 @@ impl Statement {
 
     /// Binds a "smallint" to all the values with the specified name.
     pub fn bind_int16_by_name(&mut self, name: &str, value: i16) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_int16_by_name_n(self.0, name_ptr, name.len(), value).to_result(self)
         }
     }
@@ -490,8 +490,8 @@ impl Statement {
 
     /// Binds an "int" to all the values with the specified name.
     pub fn bind_int32_by_name(&mut self, name: &str, value: i32) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_int32_by_name_n(self.0, name_ptr, name.len(), value).to_result(self)
         }
     }
@@ -506,8 +506,8 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_uint32_by_name(&mut self, name: &str, value: u32) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_uint32_by_name_n(self.0, name_ptr, name.len(), value)
                 .to_result(self)
         }
@@ -522,8 +522,8 @@ impl Statement {
     /// Binds a "bigint", "counter", "timestamp" or "time" to all values
     /// with the specified name.
     pub fn bind_int64_by_name(&mut self, name: &str, value: i64) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_int64_by_name_n(self.0, name_ptr, name.len(), value).to_result(self)
         }
     }
@@ -538,8 +538,8 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_float_by_name(&mut self, name: &str, value: f32) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_float_by_name_n(self.0, name_ptr, name.len(), value).to_result(self)
         }
     }
@@ -554,8 +554,8 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_double_by_name(&mut self, name: &str, value: f64) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_double_by_name_n(self.0, name_ptr, name.len(), value)
                 .to_result(self)
         }
@@ -574,8 +574,8 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_bool_by_name(&mut self, name: &str, value: bool) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_bool_by_name_n(
                 self.0,
                 name_ptr,
@@ -589,8 +589,8 @@ impl Statement {
     /// Binds an "ascii", "text" or "varchar" to a query or bound statement
     /// at the specified index.
     pub fn bind_string(&mut self, index: usize, value: &str) -> Result<&mut Self> {
+        let value_ptr = value.as_ptr() as *const c_char;
         unsafe {
-            let value_ptr = value.as_ptr() as *const c_char;
             cass_statement_bind_string_n(self.0, index, value_ptr, value.len()).to_result(self)
         }
     }
@@ -601,13 +601,13 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_string_by_name(&mut self, name: &str, value: &str) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
+        
+        // cass_statement_bind_string_by_name_n is incorrectly ignoring the
+        // value_length parameter so we have to allocate a new
+        // NULL-terminated string.
+        let value_cstr = std::ffi::CString::new(value)?;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
-
-            // cass_statement_bind_string_by_name_n is incorrectly ignoring the
-            // value_length parameter so we have to allocate a new
-            // NULL-terminated string.
-            let value_cstr = std::ffi::CString::new(value)?;
 
             cass_statement_bind_string_by_name_n(
                 self.0,
@@ -633,8 +633,8 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_bytes_by_name(&mut self, name: &str, mut value: Vec<u8>) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_bytes_by_name_n(
                 self.0,
                 name_ptr,
@@ -657,8 +657,8 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_uuid_by_name(&mut self, name: &str, value: Uuid) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_uuid_by_name_n(self.0, name_ptr, name.len(), value.inner())
                 .to_result(self)
         }
@@ -671,8 +671,8 @@ impl Statement {
 
     /// Binds an "inet" to all the values with the specified name.
     pub fn bind_inet_by_name(&mut self, name: &str, value: Inet) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_inet_by_name_n(self.0, name_ptr, name.len(), value.inner())
                 .to_result(self)
         }
@@ -725,8 +725,8 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_map_by_name(&mut self, name: &str, map: Map) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_collection_by_name_n(self.0, name_ptr, name.len(), map.inner())
                 .to_result(self)
         }
@@ -742,8 +742,8 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_set_by_name(&mut self, name: &str, collection: Set) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_collection_by_name_n(
                 self.0,
                 name_ptr,
@@ -765,8 +765,8 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_list_by_name(&mut self, name: &str, collection: List) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_collection_by_name_n(
                 self.0,
                 name_ptr,
@@ -787,8 +787,8 @@ impl Statement {
     /// This can only be used with statements created by
     /// cass_prepared_bind().
     pub fn bind_tuple_by_name(&mut self, name: &str, value: Tuple) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_tuple_by_name_n(self.0, name_ptr, name.len(), value.inner())
                 .to_result(self)
         }
@@ -803,8 +803,8 @@ impl Statement {
     /// Bind a user defined type to a query or bound statement with the
     /// specified name.
     pub fn bind_user_type_by_name(&mut self, name: &str, value: &UserType) -> Result<&mut Self> {
+        let name_ptr = name.as_ptr() as *const c_char;
         unsafe {
-            let name_ptr = name.as_ptr() as *const c_char;
             cass_statement_bind_user_type_by_name_n(self.0, name_ptr, name.len(), value.inner())
                 .to_result(self)
         }

--- a/src/cassandra/tuple.rs
+++ b/src/cassandra/tuple.rs
@@ -125,9 +125,9 @@ impl Tuple {
     where
         S: Into<String>,
     {
+        let value_str = value.into();
+        let value_ptr = value_str.as_ptr() as *const c_char;
         unsafe {
-            let value_str = value.into();
-            let value_ptr = value_str.as_ptr() as *const c_char;
             cass_tuple_set_string_n(self.0, index, value_ptr, value_str.len()).to_result(self)
         }
     }

--- a/src/cassandra/user_type.rs
+++ b/src/cassandra/user_type.rs
@@ -97,9 +97,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_null_by_name_n(self.0, name_ptr, name_str.len()).to_result(self)
         }
     }
@@ -114,9 +114,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_int8_by_name_n(self.0, name_ptr, name_str.len(), value)
                 .to_result(self)
         }
@@ -132,9 +132,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_int16_by_name_n(self.0, name_ptr, name_str.len(), value)
                 .to_result(self)
         }
@@ -150,9 +150,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_int32_by_name_n(self.0, name_ptr, name_str.len(), value)
                 .to_result(self)
         }
@@ -168,9 +168,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_uint32_by_name_n(self.0, name_ptr, name_str.len(), value)
                 .to_result(self)
         }
@@ -188,9 +188,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_int64_by_name_n(self.0, name_ptr, name_str.len(), value)
                 .to_result(self)
         }
@@ -206,9 +206,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_float_by_name_n(self.0, name_ptr, name_str.len(), value)
                 .to_result(self)
         }
@@ -225,9 +225,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_double_by_name_n(self.0, name_ptr, name_str.len(), value)
                 .to_result(self)
         }
@@ -246,9 +246,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_bool_by_name_n(
                 self.0,
                 name_ptr,
@@ -265,9 +265,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let value_str = value.into();
+        let value_ptr = value_str.as_ptr() as *const c_char;
         unsafe {
-            let value_str = value.into();
-            let value_ptr = value_str.as_ptr() as *const c_char;
             cass_user_type_set_string_n(self.0, index, value_ptr, value_str.len()).to_result(self)
         }
     }
@@ -278,11 +278,11 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
+        let value_str = value.into();
+        let value_ptr = value_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
-            let value_str = value.into();
-            let value_ptr = value_str.as_ptr() as *const c_char;
             cass_user_type_set_string_by_name_n(
                 self.0,
                 name_ptr,
@@ -307,9 +307,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_bytes_by_name_n(
                 self.0,
                 name_ptr,
@@ -335,9 +335,9 @@ impl UserType {
         S: Into<String>,
         U: Into<Uuid>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_uuid_by_name_n(
                 self.0,
                 name_ptr,
@@ -362,9 +362,9 @@ impl UserType {
         S: Into<String>,
         U: Into<Inet>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_inet_by_name_n(
                 self.0,
                 name_ptr,
@@ -391,9 +391,9 @@ impl UserType {
         S: Into<String>,
         V: Into<List>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_collection_by_name_n(
                 self.0,
                 name_ptr,
@@ -420,9 +420,9 @@ impl UserType {
         S: Into<String>,
         V: Into<Map>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_collection_by_name_n(
                 self.0,
                 name_ptr,
@@ -449,9 +449,9 @@ impl UserType {
         S: Into<String>,
         V: Into<Set>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_collection_by_name_n(
                 self.0,
                 name_ptr,
@@ -472,9 +472,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_tuple_by_name_n(self.0, name_ptr, name_str.len(), value.inner())
                 .to_result(self)
         }
@@ -490,9 +490,9 @@ impl UserType {
     where
         S: Into<String>,
     {
+        let name_str = name.into();
+        let name_ptr = name_str.as_ptr() as *const c_char;
         unsafe {
-            let name_str = name.into();
-            let name_ptr = name_str.as_ptr() as *const c_char;
             cass_user_type_set_user_type_by_name_n(self.0, name_ptr, name_str.len(), value.0)
                 .to_result(self)
         }

--- a/src/cassandra/uuid.rs
+++ b/src/cassandra/uuid.rs
@@ -68,16 +68,16 @@ impl Debug for Uuid {
 
 impl Display for Uuid {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        unsafe {
+        
             // Allocate an array large enough for cass_uuid_string to write to.
             let mut buf = [0u8; CASS_UUID_STRING_LENGTH];
-            cass_uuid_string(self.0, buf.as_mut_ptr() as *mut c_char);
+            unsafe {cass_uuid_string(self.0, buf.as_mut_ptr() as *mut c_char)};
             let str = CStr::from_bytes_with_nul(&buf)
                 .map_err(|_| fmt::Error)?
                 .to_str()
                 .map_err(|_| fmt::Error)?;
             fmt::Display::fmt(&str, f)
-        }
+        
     }
 }
 

--- a/src/cassandra/value.rs
+++ b/src/cassandra/value.rs
@@ -354,10 +354,10 @@ impl Value {
 
     /// Gets this value as a set iterator.
     pub fn get_set(&self) -> Result<SetIterator> {
-        unsafe {
+        
             match self.get_type() {
                 ValueType::SET | ValueType::LIST | ValueType::TUPLE => {
-                    let iter = cass_iterator_from_collection(self.0);
+                    let iter = unsafe { cass_iterator_from_collection(self.0) };
                     if iter.is_null() {
                         // No iterator, probably because this set is_null. Complain.
                         Err(CASS_ERROR_LIB_NULL_VALUE.to_error())
@@ -367,15 +367,15 @@ impl Value {
                 }
                 _ => Err(CASS_ERROR_LIB_INVALID_VALUE_TYPE.to_error()),
             }
-        }
+        
     }
 
     /// Gets this value as a map iterator.
     pub fn get_map(&self) -> Result<MapIterator> {
-        unsafe {
+        
             match self.get_type() {
                 ValueType::MAP => {
-                    let iter = cass_iterator_from_map(self.0);
+                    let iter = unsafe { cass_iterator_from_map(self.0) };
                     if iter.is_null() {
                         // No iterator, probably because this map is_null. Complain.
                         Err(CASS_ERROR_LIB_NULL_VALUE.to_error())
@@ -385,15 +385,15 @@ impl Value {
                 }
                 _ => Err(CASS_ERROR_LIB_INVALID_VALUE_TYPE.to_error()),
             }
-        }
+        
     }
 
     /// Gets an iterator over the fields of the user type in this column or errors if you ask for the wrong type
     pub fn get_user_type(&self) -> Result<UserTypeIterator> {
-        unsafe {
+        
             match self.get_type() {
                 ValueType::UDT => {
-                    let iter = cass_iterator_fields_from_user_type(self.0);
+                    let iter = unsafe {cass_iterator_fields_from_user_type(self.0) };
                     if iter.is_null() {
                         // No iterator, probably because this user_type field is null. Complain.
                         Err(CASS_ERROR_LIB_NULL_VALUE.to_error())
@@ -403,7 +403,7 @@ impl Value {
                 }
                 _ => Err(CASS_ERROR_LIB_INVALID_VALUE_TYPE.to_error()),
             }
-        }
+        
     }
 
     /// Get this value as a string slice


### PR DESCRIPTION
In these functions you use the unsafe keyword for almost the entrie function body. 

We need to mark unsafe operations more precisely using unsafe keyword. Keeping unsafe blocks small can bring many benefits. For example, when mistakes happen, we can locate any errors related to memory safety  within an unsafe block. This is the balance between Safe and Unsafe Rust. The separation is designed to make using Safe Rust as ergonomic as possible, but requires extra effort and care when writing Unsafe Rust. 

Hope this PR can help you.
Best regards.
**References**
https://doc.rust-lang.org/nomicon/safe-unsafe-meaning.html 
https://doc.rust-lang.org/book/ch19-01-unsafe-rust.html 