### PR TITLE
Expose set_exponential_reconnect function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ version number is tracked in the file `VERSION`.
 ## [Unreleased]
 ### Added
 - Added `unset_logger`, `set_slog_logger` (behind `slog` feature) and `set_log_logger` (behind `log` feature)
+- Expose `set_exponential_reconnect` function.
 
 ### Changed
 - `set_logger` is deprecated and behind `slog` feature which is enabled by default

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -16,6 +16,7 @@ use crate::cassandra_sys::cass_cluster_set_connection_idle_timeout;
 use crate::cassandra_sys::cass_cluster_set_contact_points_n;
 use crate::cassandra_sys::cass_cluster_set_core_connections_per_host;
 use crate::cassandra_sys::cass_cluster_set_credentials_n;
+use crate::cassandra_sys::cass_cluster_set_exponential_reconnect;
 use crate::cassandra_sys::cass_cluster_set_latency_aware_routing;
 use crate::cassandra_sys::cass_cluster_set_latency_aware_routing_settings;
 use crate::cassandra_sys::cass_cluster_set_load_balance_dc_aware_n;
@@ -382,6 +383,37 @@ impl Cluster {
     pub fn set_request_timeout(&mut self, timeout: Duration) -> &Self {
         unsafe {
             cass_cluster_set_request_timeout(self.0, timeout.as_millis() as u32);
+        }
+        self
+    }
+
+    /// Configures the cluster to use a reconnection policy that waits
+    /// exponentially longer between each reconnection attempt; however
+    /// will maintain a constant delay once the maximum delay is reached.
+    ///
+    /// This is the default reconnection policy.
+    ///
+    ///
+    /// Default:
+    /// - base_delay_ms: 2000ms
+    /// - max_delay_ms: 600000ms (10 minutes)
+    ///
+    /// <b>Note:</b> A random amount of jitter (+/- 15%) will be added to the pure
+    /// exponential delay value. This helps to prevent situations where multiple
+    /// connections are in the reconnection process at exactly the same time. The
+    /// jitter will never cause the delay to be less than the base delay, or more
+    /// than the max delay.
+    pub fn set_exponential_reconnect(
+        &mut self,
+        base_delay_ms: Duration,
+        max_delay_ms: Duration,
+    ) -> &Self {
+        unsafe {
+            cass_cluster_set_exponential_reconnect(
+                self.0,
+                base_delay_ms.as_millis() as u64,
+                max_delay_ms.as_millis() as u64,
+            );
         }
         self
     }


### PR DESCRIPTION
Expose the `set_exponential_reconnect` function. Working on testing this at the moment.

This is the default policy (as per the Note in https://docs.datastax.com/en/dev-app-drivers/docs/reconnectionPolicies.html), but exposing it here makes the timings configurable.

Note that the default max delay is actually 600000ms (10 minutes), not 60000ms (1 minute) - the documentation is wrong. The docstring I added for the rust wrapper fixes this error.
c.f. the constant in the C++ driver: https://github.com/datastax/cpp-driver/blob/7f193cb347948b79b1eadf44c8235ee04d66f3cf/src/constants.hpp#L127