### PR TITLE
future proof ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,12 +4,31 @@ on: [push,pull_request]
 
 jobs:
   build-and-test:
-    runs-on: ubuntu-18.04
     services:
       cassandra:
         image: cassandra:3.11.11
         ports:
           - 9042:9042
+    strategy:
+      matrix:
+        include:
+          - name: Ubuntu 20.04 - Release
+            runner: ubuntu-20.04
+            cargo_flags: --release
+
+          - name: Ubuntu 22.04 - Release
+            runner: ubuntu-22.04
+            cargo_flags: --release
+
+          - name: Ubuntu 20.04 - Debug
+            runner: ubuntu-20.04
+            cargo_flags:
+
+          - name: Ubuntu 22.04 - Debug
+            runner: ubuntu-22.04
+            cargo_flags:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v2
         with:
@@ -40,20 +59,16 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
-      - run: sudo apt update
-      - run: sudo apt install libcurl4-openssl-dev libelf-dev libdw-dev
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver-dbg_2.16.0-1_amd64.deb
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver-dev_2.16.0-1_amd64.deb
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver_2.16.0-1_amd64.deb
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.23.0/libuv1-dbg_1.23.0-1_amd64.deb
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.23.0/libuv1-dev_1.23.0-1_amd64.deb
-      - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/dependencies/libuv/v1.23.0/libuv1_1.23.0-1_amd64.deb
-      - run: sudo dpkg -i libuv1-dbg_1.23.0-1_amd64.deb libuv1-dev_1.23.0-1_amd64.deb libuv1_1.23.0-1_amd64.deb cassandra-cpp-driver_2.16.0-1_amd64.deb cassandra-cpp-driver-dbg_2.16.0-1_amd64.deb cassandra-cpp-driver-dev_2.16.0-1_amd64.deb
+      - name: cache custom ubuntu packages
+        uses: actions/cache@v3
+        with:
+          path: scripts/packages
+          key: ubuntu-packages-${{ matrix.runner }}
+      - run: scripts/install_ubuntu_packages.sh
 
+      # Check we're clean and tidy.
+      - run: cargo fmt --all --check
       # We now build all the code, then test it.
-      #
+      - run: cargo build --all ${{ matrix.cargo_flags }}
       # Tests must be run on a single thread since they share keyspaces and tables.
-      - run: |
-          cargo build --all
-      - run: |
-          cargo test -- --test-threads 1
+      - run: cargo test ${{ matrix.cargo_flags }} -- --test-threads 1

--- a/scripts/cassandra-cpp-driver.control
+++ b/scripts/cassandra-cpp-driver.control
@@ -1,0 +1,7 @@
+Package: cassandra-cpp-driver
+Version: VERSION
+Section: base
+Priority: optional
+Architecture: amd64
+Maintainer: cassandra-rs team
+Description: cassandra cpp-driver installed by cassandra-rs driver test script

--- a/scripts/install_ubuntu_packages.sh
+++ b/scripts/install_ubuntu_packages.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+cd "$(dirname "$0")"
+
+sudo apt-get update
+
+# Install dependencies of the cpp-driver even if they are already on CI so that we can run this locally
+sudo apt-get install -y libuv1 libuv1-dev cmake g++ libssl-dev zlib1g-dev
+
+# Set VERSION to one of the tags here: https://github.com/datastax/cpp-driver/tags
+# This is the version of the cpp driver that will be installed and therefore tested against
+VERSION=2.16.2
+
+PACKAGE_NAME="cassandra-cpp-driver_${VERSION}-1_amd64"
+FILE_PATH="packages/${PACKAGE_NAME}.deb"
+
+# Create package if it doesnt already exist
+if [ ! -f "$FILE_PATH" ]; then
+    rm -rf cpp-driver # Clean just in case the script failed halfway through last time
+    git clone --depth 1 --branch $VERSION https://github.com/datastax/cpp-driver
+    pushd cpp-driver
+
+    cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_INSTALL_LIBDIR:PATH=/usr/lib -Wno-error .
+    make
+
+    mkdir -p $PACKAGE_NAME/DEBIAN
+    make DESTDIR="$PACKAGE_NAME/" install
+
+    cp ../cassandra-cpp-driver.control $PACKAGE_NAME/DEBIAN/control
+    sed -i "s/VERSION/${VERSION}/g" $PACKAGE_NAME/DEBIAN/control
+    dpkg-deb --build $PACKAGE_NAME
+
+    mkdir -p ../packages
+    cp ${PACKAGE_NAME}.deb ../$FILE_PATH
+
+    popd
+    rm -rf cpp-driver
+fi
+
+sudo dpkg -i $FILE_PATH

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -466,7 +466,8 @@ fn test_rendering() {
     let result = session.execute(&query).wait().unwrap();
     println!("test_rendering: {}", result);
 
-    let row = result.iter().next().unwrap();
+    let mut row_iter = result.iter();
+    let row = row_iter.next().unwrap();
     let compaction_col = row.get_column_by_name("compaction").unwrap();
 
     // Check rendering of a column


### PR DESCRIPTION
Same as https://github.com/Metaswitch/cassandra-sys-rs/pull/50
I also noticed we were missing `cargo fmt` on this repo so I copied that over.