### PR TITLE
Remove all instances of mem::zeroed

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,7 @@ jobs:
         with:
           profile: minimal
           toolchain: stable
+      - run: sudo apt update
       - run: sudo apt install libcurl4-openssl-dev libelf-dev libdw-dev
       - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver-dbg_2.16.0-1_amd64.deb
       - run: wget http://downloads.datastax.com/cpp-driver/ubuntu/18.04/cassandra/v2.16.0/cassandra-cpp-driver-dev_2.16.0-1_amd64.deb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ version number is tracked in the file `VERSION`.
 ### Changed
 
 ### Fixed
+- Inet::Default now returns an ipv4 address of 0.0.0.0 instead of the previous value which was semantically incorrect.
 
 ## [1.1.0] - 2022-03-31
 ### Added

--- a/src/cassandra/error.rs
+++ b/src/cassandra/error.rs
@@ -313,13 +313,13 @@ pub(crate) unsafe fn get_lossy_string<F>(get: F) -> Option<String>
 where
     F: Fn(*mut *const ::std::os::raw::c_char, *mut usize) -> CassError_,
 {
-    let mut msg = mem::zeroed();
-    let mut msg_len = mem::zeroed();
+    let mut msg = std::ptr::null();
+    let mut msg_len = 0;
     match (get)(&mut msg, &mut msg_len) {
         CASS_OK => (),
         _ => return None,
     }
-    let slice = slice::from_raw_parts(msg as *const u8, msg_len as usize);
+    let slice = slice::from_raw_parts(msg as *const u8, msg_len);
     Some(String::from_utf8_lossy(slice).into_owned())
 }
 

--- a/src/cassandra/future.rs
+++ b/src/cassandra/future.rs
@@ -135,10 +135,10 @@ unsafe fn payloads_from_future(future: *mut _Future) -> Result<CustomPayloadResp
     (0..cp_count)
         .into_iter()
         .map(|index| {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
-            let mut value = mem::zeroed();
-            let mut value_size = mem::zeroed();
+            let mut name = std::ptr::null();
+            let mut name_length = 0;
+            let mut value = std::ptr::null();
+            let mut value_size = 0;
 
             cass_future_custom_payload_item(
                 future,

--- a/src/cassandra/iterator.rs
+++ b/src/cassandra/iterator.rs
@@ -88,12 +88,12 @@ impl Iterator for UserTypeIterator {
 impl UserTypeIterator {
     fn get_field_name(&mut self) -> String {
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
+            let mut name = std::ptr::null();
+            let mut name_length = 0;
             cass_iterator_get_user_type_field_name(self.0, &mut name, &mut name_length)
                 .to_result(())
                 .and_then(|_| {
-                    let slice = slice::from_raw_parts(name as *const u8, name_length as usize);
+                    let slice = slice::from_raw_parts(name as *const u8, name_length);
                     let name = str::from_utf8(slice)?.to_owned();
                     Ok(name)
                 })
@@ -200,13 +200,12 @@ impl Iterator for FieldIterator {
             match cass_iterator_next(self.0) {
                 cass_false => None,
                 cass_true => {
-                    let mut name = mem::zeroed();
-                    let mut name_length = mem::zeroed();
+                    let mut name = std::ptr::null();
+                    let mut name_length = 0;
                     cass_iterator_get_meta_field_name(self.0, &mut name, &mut name_length)
                         .to_result(())
                         .and_then(|_| {
-                            let slice =
-                                slice::from_raw_parts(name as *const u8, name_length as usize);
+                            let slice = slice::from_raw_parts(name as *const u8, name_length);
                             let name = str::from_utf8(slice)?.to_owned();
                             let value = Value::build(cass_iterator_get_meta_field_value(self.0));
                             Ok(Some(Field { name, value }))

--- a/src/cassandra/prepared.rs
+++ b/src/cassandra/prepared.rs
@@ -49,15 +49,15 @@ impl PreparedStatement {
 
     /// Gets the name of a parameter at the specified index.
     pub fn parameter_name(&self, index: usize) -> Result<&str> {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
             cass_prepared_parameter_name(self.0, index, &mut name, &mut name_length)
                 .to_result(())
                 .and_then(|_| {
                     Ok(str::from_utf8(slice::from_raw_parts(
                         name as *const u8,
-                        name_length as usize,
+                        name_length,
                     ))?)
                 })
         }

--- a/src/cassandra/result.rs
+++ b/src/cassandra/result.rs
@@ -94,13 +94,13 @@ impl CassResult {
 
     /// Gets the column name at index for the specified result.
     pub fn column_name(&self, index: usize) -> Result<&str> {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
             cass_result_column_name(self.0, index, &mut name, &mut name_length)
                 .to_result(())
                 .and_then(|_| {
-                    let slice = slice::from_raw_parts(name as *const u8, name_length as usize);
+                    let slice = slice::from_raw_parts(name as *const u8, name_length);
                     Ok(str::from_utf8(slice)?)
                 })
         }
@@ -146,17 +146,12 @@ impl CassResult {
             return Ok(None);
         }
 
+        let mut token_ptr = std::ptr::null();
+        let mut token_length = 0;
         unsafe {
-            let mut token_ptr = mem::zeroed();
-            let mut token_length = mem::zeroed();
             cass_result_paging_state_token(self.0, &mut token_ptr, &mut token_length)
                 .to_result(())
-                .map(|_| {
-                    Some(
-                        slice::from_raw_parts(token_ptr as *const u8, token_length as usize)
-                            .to_vec(),
-                    )
-                })
+                .map(|_| Some(slice::from_raw_parts(token_ptr as *const u8, token_length).to_vec()))
         }
     }
 

--- a/src/cassandra/schema/aggregate_meta.rs
+++ b/src/cassandra/schema/aggregate_meta.rs
@@ -45,9 +45,9 @@ impl AggregateMeta {
 
     /// Gets the name of the aggregate.
     pub fn get_name(&self) -> String {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
             cass_aggregate_meta_name(self.0, &mut name, &mut name_length);
             raw2utf8(name, name_length).expect("must be utf8")
         }
@@ -55,9 +55,9 @@ impl AggregateMeta {
 
     /// Gets the full name of the aggregate.
     pub fn full_name(&self) -> String {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
             cass_aggregate_meta_full_name(self.0, &mut name, &mut name_length);
             raw2utf8(name, name_length).expect("must be utf8")
         }

--- a/src/cassandra/schema/column_meta.rs
+++ b/src/cassandra/schema/column_meta.rs
@@ -40,11 +40,11 @@ impl ColumnMeta {
 
     /// Gets the name of the column.
     pub fn name(&self) -> String {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
             cass_column_meta_name(self.0, &mut name, &mut name_length);
-            let slice = slice::from_raw_parts(name as *const u8, name_length as usize);
+            let slice = slice::from_raw_parts(name as *const u8, name_length);
             str::from_utf8(slice).expect("must be utf8").to_owned()
         }
     }

--- a/src/cassandra/schema/function_meta.rs
+++ b/src/cassandra/schema/function_meta.rs
@@ -46,16 +46,13 @@ impl FunctionMeta {
 
     /// Gets the name of the function.
     pub fn get_name(&self) -> String {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
             cass_function_meta_name(self.0, &mut name, &mut name_length);
-            str::from_utf8(slice::from_raw_parts(
-                name as *const u8,
-                name_length as usize,
-            ))
-            .expect("must be utf8")
-            .to_owned()
+            str::from_utf8(slice::from_raw_parts(name as *const u8, name_length))
+                .expect("must be utf8")
+                .to_owned()
         }
     }
 
@@ -63,46 +60,37 @@ impl FunctionMeta {
     /// function's name and the function's signature:
     /// "name(type1 type2.. typeN)".
     pub fn full_name(&self) -> String {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
             cass_function_meta_full_name(self.0, &mut name, &mut name_length);
-            str::from_utf8(slice::from_raw_parts(
-                name as *const u8,
-                name_length as usize,
-            ))
-            .expect("must be utf8")
-            .to_owned()
+            str::from_utf8(slice::from_raw_parts(name as *const u8, name_length))
+                .expect("must be utf8")
+                .to_owned()
         }
     }
 
     /// Gets the body of the function.
     pub fn body(&self) -> String {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
             cass_function_meta_body(self.0, &mut name, &mut name_length);
-            str::from_utf8(slice::from_raw_parts(
-                name as *const u8,
-                name_length as usize,
-            ))
-            .expect("must be utf8")
-            .to_owned()
+            str::from_utf8(slice::from_raw_parts(name as *const u8, name_length))
+                .expect("must be utf8")
+                .to_owned()
         }
     }
 
     /// Gets the language of the function.
     pub fn language(&self) -> String {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
             cass_function_meta_language(self.0, &mut name, &mut name_length);
-            str::from_utf8(slice::from_raw_parts(
-                name as *const u8,
-                name_length as usize,
-            ))
-            .expect("must be utf8")
-            .to_owned()
+            str::from_utf8(slice::from_raw_parts(name as *const u8, name_length))
+                .expect("must be utf8")
+                .to_owned()
         }
     }
 
@@ -118,11 +106,10 @@ impl FunctionMeta {
 
     /// Gets the function's argument name and type for the provided index.
     pub fn argument(&self, index: usize) -> Result<()> {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
+        let mut data_type = std::ptr::null();
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
-            let mut data_type = mem::zeroed();
-
             cass_function_meta_argument(self.0, index, &mut name, &mut name_length, &mut data_type)
                 .to_result(())
         }

--- a/src/cassandra/schema/keyspace_meta.rs
+++ b/src/cassandra/schema/keyspace_meta.rs
@@ -143,9 +143,9 @@ impl KeyspaceMeta {
 
     /// Gets the name of the keyspace.
     pub fn name(&self) -> String {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
             cass_keyspace_meta_name(self.0, &mut name, &mut name_length);
             raw2utf8(name, name_length).expect("must be utf8")
         }

--- a/src/cassandra/schema/table_meta.rs
+++ b/src/cassandra/schema/table_meta.rs
@@ -62,16 +62,13 @@ impl TableMeta {
 
     /// Gets the name of the table.
     pub fn get_name(&self) -> String {
+        let mut name = std::ptr::null();
+        let mut name_length = 0;
         unsafe {
-            let mut name = mem::zeroed();
-            let mut name_length = mem::zeroed();
             cass_table_meta_name(self.0, &mut name, &mut name_length);
-            str::from_utf8(slice::from_raw_parts(
-                name as *const u8,
-                name_length as usize,
-            ))
-            .expect("must be utf8")
-            .to_owned()
+            str::from_utf8(slice::from_raw_parts(name as *const u8, name_length))
+                .expect("must be utf8")
+                .to_owned()
         }
     }
 

--- a/src/cassandra/uuid.rs
+++ b/src/cassandra/uuid.rs
@@ -42,7 +42,10 @@ impl Protected<_Uuid> for Uuid {
 
 impl Default for Uuid {
     fn default() -> Uuid {
-        unsafe { ::std::mem::zeroed() }
+        Uuid(_Uuid {
+            time_and_version: 0,
+            clock_seq_and_node: 0,
+        })
     }
 }
 
@@ -158,9 +161,12 @@ impl From<Uuid> for uuid::Uuid {
 impl str::FromStr for Uuid {
     type Err = Error;
     fn from_str(str: &str) -> Result<Uuid> {
+        let str_ptr = str.as_ptr() as *const c_char;
+        let mut uuid = _Uuid {
+            time_and_version: 0,
+            clock_seq_and_node: 0,
+        };
         unsafe {
-            let mut uuid = mem::zeroed();
-            let str_ptr = str.as_ptr() as *const c_char;
             cass_uuid_from_string_n(str_ptr, str.len(), &mut uuid)
                 .to_result(())
                 .and_then(|_| Ok(Uuid(uuid)))
@@ -209,8 +215,11 @@ impl UuidGen {
 
     /// Generates a V1 (time) UUID.
     pub fn gen_time(&self) -> Uuid {
+        let mut output = _Uuid {
+            time_and_version: 0,
+            clock_seq_and_node: 0,
+        };
         unsafe {
-            let mut output: _Uuid = mem::zeroed();
             cass_uuid_gen_time(self.0, &mut output);
             Uuid(output)
         }
@@ -218,8 +227,11 @@ impl UuidGen {
 
     /// Generates a new V4 (random) UUID
     pub fn gen_random(&self) -> Uuid {
+        let mut output = _Uuid {
+            time_and_version: 0,
+            clock_seq_and_node: 0,
+        };
         unsafe {
-            let mut output: _Uuid = mem::zeroed();
             cass_uuid_gen_random(self.0, &mut output);
             Uuid(output)
         }
@@ -239,8 +251,11 @@ impl UuidGen {
     /// # }
     /// ```
     pub fn gen_from_time(&self, timestamp: u64) -> Uuid {
+        let mut output = _Uuid {
+            time_and_version: 0,
+            clock_seq_and_node: 0,
+        };
         unsafe {
-            let mut output: _Uuid = mem::zeroed();
             cass_uuid_gen_from_time(self.0, timestamp, &mut output);
             Uuid(output)
         }


### PR DESCRIPTION
std::mem::zeroed is unsafe so the less times we call it, the easier it is to reason about the correctness of our code. (One less invariant to keep in our head)

A good example of this going wrong was: https://github.com/Metaswitch/cassandra-rs/pull/133

This PR should cause no functional changes, all the code it replaces is correct and was not invoking any UB. The goal is just to make our unsafe usage easier to audit for correctness.

The one exception to this is `Inet::default()` but this was not changed to fix UB but to give a semantically correct default value.