### PR TITLE
reorder lines in Cluster::connect_keyspace

### DIFF
--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -209,16 +209,18 @@ impl Cluster {
     /// Connects to the cassandra cluster, setting the keyspace of the session.
     pub async fn connect_keyspace(&mut self, keyspace: &str) -> Result<Session> {
         let session = Session::new();
-        let keyspace_ptr = keyspace.as_ptr() as *const c_char;
-        let connect_keyspace = unsafe {
-            cass_session_connect_keyspace_n(
-                session.inner(),
-                self.inner(),
-                keyspace_ptr,
-                keyspace.len(),
-            )
+        let connect_future = {
+            let keyspace_ptr = keyspace.as_ptr() as *const c_char;
+            let connect_keyspace = unsafe {
+                cass_session_connect_keyspace_n(
+                    session.inner(),
+                    self.inner(),
+                    keyspace_ptr,
+                    keyspace.len(),
+                )
+            };
+            CassFuture::build(session, connect_keyspace)
         };
-        let connect_future = CassFuture::build(session, connect_keyspace);
         connect_future.await
     }
 


### PR DESCRIPTION
Hello.
I try to build multi-thread tokio runtime and https://github.com/swizard0/ero
I have a compiler error

```rust
error: future cannot be sent between threads safely
   --> src/main.rs:49:41
    |
49  |       supervisor_pid.spawn_link_permanent(cassandra_server.run(
    |  _________________________________________^
50  | |         supervisor_server.pid(),
51  | |         3,
52  | |         core_params.cassandra,
53  | |     ));
    | |_____^ future is not `Send`
    |
    = help: within `impl Future<Output = ()>`, the trait `Send` is not implemented for `*const i8`
note: future is not `Send` as this value is used across an await
   --> /home/user/.cargo/registry/src/github.com-1ecc6299db9ec823/cassandra-cpp-2.0.0/src/cassandra/cluster.rs:222:23
    |
212 |         let keyspace_ptr = keyspace.as_ptr() as *const c_char;
    |             ------------ has type `*const i8` which is not `Send`
...
222 |         connect_future.await
    |                       ^^^^^^ await occurs here, with `keyspace_ptr` maybe used later
223 |     }
    |     - `keyspace_ptr` is later dropped here
note: required by a bound in `SupervisorPid::spawn_link_permanent`
   --> /home/user/.cargo/git/checkouts/ero-45b211edd1ecc937/425f32f/src/supervisor.rs:49:89
    |
49  |     pub fn spawn_link_permanent<F>(&mut self, future: F) where F: Future<Output = ()> + Send + 'static {
    |                                                                                         ^^^^ required by this bound in `SupervisorPid::spawn_link_permanent`
```