### PR TITLE
Fix some warnings from rustc and clippy

### DIFF
--- a/examples/collections.rs
+++ b/examples/collections.rs
@@ -40,13 +40,11 @@ async fn do_work(session: &Session) -> Result<()> {
             }
         };
         let emails_iter: SetIterator = row.get_by_name("email")?;
-        let emails: Vec<String> = emails_iter
-            .map(|v| Ok(v.get_string()?))
-            .collect::<Result<_>>()?;
+        let emails: Vec<String> = emails_iter.map(|v| v.get_string()).collect::<Result<_>>()?;
         let last_name: String = row.get_by_name("last_name")?;
         let phone_numbers_iter: SetIterator = row.get_by_name("phone_numbers")?;
         let phone_numbers: Vec<String> = phone_numbers_iter
-            .map(|v| Ok(v.get_string()?))
+            .map(|v| v.get_string())
             .collect::<Result<_>>()?;
         let title: i32 = row.get_by_name("title")?;
         println!(

--- a/src/cassandra/cluster.rs
+++ b/src/cassandra/cluster.rs
@@ -231,9 +231,7 @@ impl Cluster {
     /// Default: version 4
     ///
     pub fn set_protocol_version(&mut self, protocol_version: CqlProtocol) -> Result<&mut Self> {
-        unsafe {
-            cass_cluster_set_protocol_version(self.0, protocol_version as i32).to_result(self)
-        }
+        unsafe { cass_cluster_set_protocol_version(self.0, protocol_version).to_result(self) }
     }
 
     /// Sets the number of IO threads. This is the number of threads

--- a/src/cassandra/custom_payload.rs
+++ b/src/cassandra/custom_payload.rs
@@ -47,13 +47,8 @@ impl CustomPayload {
     pub fn set(&self, name: String, value: &[u8]) -> Result<()> {
         unsafe {
             let name_ptr = name.as_ptr() as *const c_char;
-            Ok(cass_custom_payload_set_n(
-                self.0,
-                name_ptr,
-                name.len(),
-                value.as_ptr(),
-                value.len(),
-            ))
+            cass_custom_payload_set_n(self.0, name_ptr, name.len(), value.as_ptr(), value.len());
+            Ok(())
         }
     }
 }

--- a/src/cassandra/future.rs
+++ b/src/cassandra/future.rs
@@ -151,7 +151,6 @@ impl Completable for PreparedStatement {
 unsafe fn payloads_from_future(future: *mut _Future) -> Result<CustomPayloadResponse> {
     let cp_count = cass_future_custom_payload_item_count(future);
     (0..cp_count)
-        .into_iter()
         .map(|index| {
             let mut name = std::ptr::null();
             let mut name_length = 0;

--- a/src/cassandra/inet.rs
+++ b/src/cassandra/inet.rs
@@ -98,7 +98,7 @@ impl FromStr for Inet {
         unsafe {
             cass_inet_from_string_n(s_ptr, s.len(), &mut inet)
                 .to_result(())
-                .and_then(|_| Ok(Inet(inet)))
+                .map(|_| Inet(inet))
         }
     }
 }

--- a/src/cassandra/result.rs
+++ b/src/cassandra/result.rs
@@ -60,9 +60,9 @@ impl Protected<*const _CassResult> for CassResult {
 
 impl Debug for CassResult {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "Result row count: {:?}\n", self.row_count())?;
+        writeln!(f, "Result row count: {:?}", self.row_count())?;
         for row in self.iter() {
-            write!(f, "{:?}\n", row)?;
+            writeln!(f, "{:?}", row)?;
         }
         Ok(())
     }
@@ -70,9 +70,9 @@ impl Debug for CassResult {
 
 impl Display for CassResult {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "Result row count: {}\n", self.row_count())?;
+        writeln!(f, "Result row count: {}", self.row_count())?;
         for row in self.iter() {
-            write!(f, "{}\n", row)?;
+            writeln!(f, "{}", row)?;
         }
         Ok(())
     }

--- a/src/cassandra/session.rs
+++ b/src/cassandra/session.rs
@@ -109,7 +109,7 @@ impl Session {
     /// Creates a statement with the given query.
     pub fn statement(&self, query: impl AsRef<str>) -> Statement {
         let query = query.as_ref();
-        let param_count = query.matches("?").count();
+        let param_count = query.matches('?').count();
         Statement::new(self.clone(), query, param_count)
     }
 

--- a/src/cassandra/ssl.rs
+++ b/src/cassandra/ssl.rs
@@ -37,7 +37,7 @@ enhance_nullary_enum!(SslVerifyFlag, CassSslVerifyFlags, {
 fn to_bitset(flags: &[SslVerifyFlag]) -> i32 {
     let mut res = 0;
     for f in flags.iter() {
-        res = res | f.inner() as u32;
+        res |= f.inner() as u32;
     }
     res as i32
 }

--- a/src/cassandra/uuid.rs
+++ b/src/cassandra/uuid.rs
@@ -172,7 +172,7 @@ impl str::FromStr for Uuid {
         unsafe {
             cass_uuid_from_string_n(str_ptr, str.len(), &mut uuid)
                 .to_result(())
-                .and_then(|_| Ok(Uuid(uuid)))
+                .map(|_| Uuid(uuid))
         }
     }
 }

--- a/src/cassandra/value.rs
+++ b/src/cassandra/value.rs
@@ -260,8 +260,8 @@ impl Display for Value {
             Ok(())
         } else {
             match self.get_type() {
-                ValueType::UNKNOWN => write!(f, "{}", "unknown"),
-                ValueType::CUSTOM => write!(f, "{}", "custom"),
+                ValueType::UNKNOWN => write!(f, "unknown"),
+                ValueType::CUSTOM => write!(f, "custom"),
                 ValueType::ASCII | ValueType::TEXT | ValueType::VARCHAR => {
                     write_value(f, self.get_string(), |f, v| write!(f, "{}", v))
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! This is a wrapper around the DataStax C++ driver for Cassandra. It aims to be 100% safe with minimal overhead added
 #![deny(missing_docs)]
 #![allow(unknown_lints)]
-#![allow(doc_markdown)]
+#![allow(clippy::doc_markdown)]
 #![allow(unused_imports)] // TODO: remove
 #![allow(dead_code)] // TODO: remove
 // `error_chain!` can recurse deeply

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -139,7 +139,7 @@ fn basic_from_result(result: CassResult) -> Result<Option<Basic>> {
                 addr: row.get(9)?,
                 tu: row.get(10)?,
                 id: row.get(11)?,
-                ct: Udt { dt: dt, tm: tm },
+                ct: Udt { dt, tm },
                 txt: row.get(13)?,
             }))
         }
@@ -330,7 +330,7 @@ async fn test_null_retrieval() -> Result<()> {
     assert!(!row.get_column(0).unwrap().is_null());
 
     let v: bool = row.get(1).unwrap();
-    assert_eq!(v, true);
+    assert!(v);
     assert!(!row.get_column(1).unwrap().is_null());
 
     let v: f32 = row.get(2).unwrap();
@@ -387,8 +387,8 @@ async fn test_null_retrieval() -> Result<()> {
 #[tokio::test]
 async fn test_null_insertion() -> Result<()> {
     let session = help::create_test_session().await;
-    help::create_example_keyspace(&session);
-    create_basic_table(&session);
+    help::create_example_keyspace(&session).await;
+    create_basic_table(&session).await.unwrap();
 
     // Insert some explicit nulls.
     let mut s = session.statement(
@@ -480,10 +480,10 @@ async fn test_rendering() -> Result<()> {
     let keyspace_col = row.get_column_by_name("keyspace_name").unwrap();
     let str: &str = keyspace_col.get_str().unwrap();
     println!("Str is {}", str);
-    assert!(str.len() > 0, "empty str");
+    assert!(!str.is_empty(), "empty str");
     let str: String = keyspace_col.get_string().unwrap();
     println!("String is {}", str);
-    assert!(str.len() > 0, "empty string");
+    assert!(!str.is_empty(), "empty string");
 
     // Check invalid retrieval type.
     keyspace_col

--- a/tests/logging.rs
+++ b/tests/logging.rs
@@ -1,5 +1,6 @@
 mod help;
 
+#[cfg(any(feature = "slog", feature = "log"))]
 use cassandra_cpp::*;
 
 #[cfg(feature = "slog")]
@@ -85,6 +86,7 @@ async fn test_log_logger() {
     );
     assert_eq!(record.key_values(), vec!());
 }
+
 #[tokio::test]
 async fn test_metrics() {
     // This is just a check that metrics work and actually notice requests.

--- a/tests/maps.rs
+++ b/tests/maps.rs
@@ -9,10 +9,10 @@ struct Pair {
     value: i32,
 }
 
-static CREATE_TABLE: &'static str =
+static CREATE_TABLE: &str =
     "CREATE TABLE IF NOT EXISTS examples.maps (key text, items map<text, int>, \
      PRIMARY KEY (key))";
-static SELECT_QUERY: &'static str = "SELECT items FROM examples.maps WHERE key = ?";
+static SELECT_QUERY: &str = "SELECT items FROM examples.maps WHERE key = ?";
 
 async fn insert_into_maps(session: &Session, key: &str, items: &Vec<Pair>) -> Result<()> {
     let mut insert_statement =

--- a/tests/paging.rs
+++ b/tests/paging.rs
@@ -5,15 +5,15 @@ use cassandra_cpp::*;
 static NUM_CONCURRENT_REQUESTS: usize = 100;
 const PAGE_SIZE: i32 = 10;
 
-static CREATE_TABLE: &'static str =
+static CREATE_TABLE: &str =
     "CREATE TABLE IF NOT EXISTS examples.paging (key ascii, value text, PRIMARY KEY \
      (key));";
-static SELECT_QUERY: &'static str = "SELECT * FROM paging";
-static INSERT_QUERY: &'static str = "INSERT INTO paging (key, value) VALUES (?, ?);";
+static SELECT_QUERY: &str = "SELECT * FROM paging";
+static INSERT_QUERY: &str = "INSERT INTO paging (key, value) VALUES (?, ?);";
 
 // FIXME uuids not yet working
 async fn insert_into_paging(session: &Session /* , uuid_gen:&mut UuidGen */) -> Result<()> {
-    let mut futures = Vec::with_capacity(NUM_CONCURRENT_REQUESTS as usize);
+    let mut futures = Vec::with_capacity(NUM_CONCURRENT_REQUESTS);
     let prepared_statement = session.prepare(INSERT_QUERY).await?;
 
     for i in 0..NUM_CONCURRENT_REQUESTS {

--- a/tests/types.rs
+++ b/tests/types.rs
@@ -25,7 +25,9 @@ fn test_parsing_printing_consistency() {
 
     for c in all {
         let s = c.to_string();
-        let c2: Consistency = s.parse().expect(&format!("Failed on {:?} as {}", c, s));
+        let c2: Consistency = s
+            .parse()
+            .unwrap_or_else(|_| panic!("Failed on {:?} as {}", c, s));
         assert_eq!(c2, *c, "with intermediate {}", s);
     }
 
@@ -52,7 +54,9 @@ fn test_using_loglevel() {
 fn test_parsing_printing_loglevel() {
     for v in LogLevel::variants() {
         let s = v.to_string();
-        let v2: LogLevel = s.parse().expect(&format!("Failed on {:?} as {}", v, s));
+        let v2: LogLevel = s
+            .parse()
+            .unwrap_or_else(|_| panic!("Failed on {:?} as {}", v, s));
         assert_eq!(v2, *v, "with intermediate {}", s);
     }
 
@@ -69,20 +73,19 @@ fn test_parsing_printing_loglevel() {
 #[test]
 fn test_using_ssl_verify_flags() {
     let mut ssl = Ssl::default();
-    ssl.set_verify_flags(&vec![]);
-    ssl.set_verify_flags(&vec![SslVerifyFlag::NONE]);
-    ssl.set_verify_flags(&vec![SslVerifyFlag::PEER_CERT]);
-    ssl.set_verify_flags(&vec![
-        SslVerifyFlag::PEER_IDENTITY_DNS,
-        SslVerifyFlag::PEER_CERT,
-    ]);
+    ssl.set_verify_flags(&[]);
+    ssl.set_verify_flags(&[SslVerifyFlag::NONE]);
+    ssl.set_verify_flags(&[SslVerifyFlag::PEER_CERT]);
+    ssl.set_verify_flags(&[SslVerifyFlag::PEER_IDENTITY_DNS, SslVerifyFlag::PEER_CERT]);
 }
 
 #[test]
 fn test_parsing_printing_ssl_verify_flags() {
     for v in SslVerifyFlag::variants() {
         let s = v.to_string();
-        let v2: SslVerifyFlag = s.parse().expect(&format!("Failed on {:?} as {}", v, s));
+        let v2: SslVerifyFlag = s
+            .parse()
+            .unwrap_or_else(|_| panic!("Failed on {:?} as {}", v, s));
         assert_eq!(v2, *v, "with intermediate {}", s);
     }
 
@@ -114,7 +117,9 @@ fn test_using_cql_protocol_version() {
 fn test_parsing_printing_batch_type() {
     for v in BatchType::variants() {
         let s = v.to_string();
-        let v2: BatchType = s.parse().expect(&format!("Failed on {:?} as {}", v, s));
+        let v2: BatchType = s
+            .parse()
+            .unwrap_or_else(|_| panic!("Failed on {:?} as {}", v, s));
         assert_eq!(v2, *v, "with intermediate {}", s);
     }
 

--- a/tests/uuids.rs
+++ b/tests/uuids.rs
@@ -3,10 +3,10 @@ mod help;
 use cassandra_cpp::*;
 use std::str::FromStr;
 
-static TRUNCATE_QUERY: &'static str = "TRUNCATE examples.log;";
-static INSERT_QUERY: &'static str = "INSERT INTO examples.log (key, time, entry) VALUES (?, ?, ?);";
-static SELECT_QUERY: &'static str = "SELECT * FROM examples.log WHERE key = ?";
-static CREATE_TABLE: &'static str =
+static TRUNCATE_QUERY: &str = "TRUNCATE examples.log;";
+static INSERT_QUERY: &str = "INSERT INTO examples.log (key, time, entry) VALUES (?, ?, ?);";
+static SELECT_QUERY: &str = "SELECT * FROM examples.log WHERE key = ?";
+static CREATE_TABLE: &str =
     "CREATE TABLE IF NOT EXISTS examples.log (key text, time timeuuid, entry text, \
      PRIMARY KEY (key, time));";
 
@@ -56,13 +56,13 @@ async fn test_uuids() -> Result<()> {
     println!("{:?}", results);
 
     // Check the resulting UUIDs are in order.
-    results.sort_by_key(|ref kv| kv.0);
+    results.sort_by_key(|kv| kv.0);
     assert_eq!(results[0].1, "Log entry #1");
     assert_eq!(results[1].1, "Log entry #2");
     assert_eq!(results[2].1, "Log entry #3");
     assert_eq!(results[3].1, "Log entry #4");
 
-    let mut uniques = results.iter().map(|ref kv| kv.0).collect::<Vec<Uuid>>();
+    let mut uniques = results.iter().map(|kv| kv.0).collect::<Vec<Uuid>>();
     uniques.dedup();
     assert_eq!(4, uniques.len());
 
@@ -71,7 +71,7 @@ async fn test_uuids() -> Result<()> {
 
 #[test]
 fn test_uuids_from() {
-    const TEST_UUID: &'static str = "a0a1a2a3-a4a5-a6a7-a8a9-aaabacadaeaf";
+    const TEST_UUID: &str = "a0a1a2a3-a4a5-a6a7-a8a9-aaabacadaeaf";
     let uuid_id_from_str = uuid::Uuid::parse_str(TEST_UUID).unwrap();
     let cass_id_from_str = Uuid::from_str(TEST_UUID).unwrap();
 


### PR DESCRIPTION
A lot of these are super minor, but a few are important like the missing awaits in `tests/basic.rs`
Happy to remove all the minor stuff to land the important ones, but the minor stuff was really easy to do, just: `cargo clippy --fix`