### PR TITLE
Release 2.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ version number is tracked in the file `VERSION`.
 
 ### Fixed
 
+## [2.0.1] - 2023-06-08
+
+### Fixed
+- Fix bug where `connect_keyspace` was not `Send`
+- Fixed some rustc and clippy warnings.
+
 ## [2.0.0] - 2023-03-13
 ### Changed
 - All functions were converted to be asynchronous. This allows for better performance, as asynchronous functions can run in parallel and make better use of system resources.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ keywords = [ "Cassandra", "binding", "CQL", "client", "database" ]
 categories = [ "api-bindings", "database", "external-ffi-bindings", "asynchronous" ]
 license = "Apache-2.0"
 name = "cassandra-cpp"
-version = "2.0.1-pre"
+version = "2.0.1"
 authors = ["Tupshin Harper <tupshin@tupshin.com>", "Keith Wansbrough <Keith.Wansbrough@metaswitch.com>"]
 edition = "2018"
 


### PR DESCRIPTION
I'm treating the first fix as a bugfix and not bumping the minor version, even though technically it's an API change (adding back `Send`).