### PR TITLE
Enable manual workflow trigger

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build
 
-on: [push,pull_request]
+on: [push,pull_request,workflow_dispatch]
 
 jobs:
   build-and-test:


### PR DESCRIPTION
Add a button to manually trigger the build workflow, per https://docs.github.com/en/actions/using-workflows/manually-running-a-workflow#configuring-a-workflow-to-run-manually