### PR TITLE
Bug: iterator lifetime not tied to result

### DIFF
--- a/src/cassandra/result.rs
+++ b/src/cassandra/result.rs
@@ -160,7 +160,7 @@ impl CassResult {
 
     /// Creates a new iterator for the specified result. This can be
     /// used to iterate over rows in the result.
-    pub fn iter(&self) -> ResultIterator {
+    pub fn iter<'a>(&'a self) -> ResultIterator<'a> {
         unsafe {
             ResultIterator(
                 cass_iterator_from_result(self.0),


### PR DESCRIPTION
This can lead to the underlying data being dropped before the data from the iterator has been used, which can lead to crashes.

Thanks to Simon for the report.