### PR TITLE
Make Row::iter public

### DIFF
--- a/src/cassandra/row.rs
+++ b/src/cassandra/row.rs
@@ -375,7 +375,7 @@ impl<'a> Row<'a> {
 
     /// Creates a new iterator for the specified row. This can be
     /// used to iterate over columns in a row.
-    fn iter(&'a self) -> RowIterator<'a> {
+    pub fn iter(&'a self) -> RowIterator<'a> {
         unsafe { RowIterator(cass_iterator_from_row(self.0), PhantomData) }
     }
 }


### PR DESCRIPTION
It seems like this was missed in https://github.com/Metaswitch/cassandra-rs/commit/299e6ac50f87eb2823a373baec37b590a74994ee