### PR TITLE
Bump to v3.0.2-pre and update authors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ keywords = [ "Cassandra", "binding", "CQL", "client", "database" ]
 categories = [ "api-bindings", "database", "external-ffi-bindings", "asynchronous" ]
 license = "Apache-2.0"
 name = "cassandra-cpp"
-version = "3.0.1"
-authors = ["Tupshin Harper <tupshin@tupshin.com>", "Keith Wansbrough <Keith.Wansbrough@metaswitch.com>"]
+version = "3.0.2-pre"
+authors = ["Keith Wansbrough <kwansbrough@microsoft.com>"]
 edition = "2018"
 
 [dependencies]


### PR DESCRIPTION
Also take opportunity to fix up authors:

Tupshin hasn't been involved since the fork and this has evolved greatly since then.

Also update my email address to reflect my current employer (Microsoft); Metaswitch is a brand of Microsoft.